### PR TITLE
Bugfix: marker close should navigate back to original image opener

### DIFF
--- a/src/svelte/components/MarkerPopup.svelte
+++ b/src/svelte/components/MarkerPopup.svelte
@@ -38,9 +38,10 @@
 		else {
 			// Navigate back if this was the original image opener
 			// This will auto-close a still opened marker
-			if($current && image.opts.secondaryTo && $current.id != image.id && data.micrioLink?.id == $current.id)
+			if($current && !image.opts.secondaryTo && $current.id != image.id && data.micrioLink?.id == $current.id) {
 				micrio.open(image.id);
-			else image.state.marker.set(undefined);
+				image.state.marker.set(undefined);
+			} else image.state.marker.set(undefined);
 		}
 	}
 


### PR DESCRIPTION
Dit issue lijkt gewoon te komen door een uitroeptekentje dat in de port van v4 naar v5 verloren is geraakt.
Maar: de marker popup wordt ook niet meer gesloten terwijl dat met dezelfde code bij v4 wel gebeurt! Dus ik heb daar een extra regel voor toegevoegd. Maar misschien zit er dus eigenlijk een bug waar een micrio.open gewoon altijd de huidige open marker popup moet sluiten? Ik ben benieuwd wat hier de verdict is!

Testen: 
- gebruik micrio ID "vsmQN" in index.html
- klik op marker "Marker links to another Micrio image"
- kruisje van de popup zou weer terug moeten gaan naar de vorige plaat