### PR TITLE
Feature/sanitize asset src

### DIFF
--- a/src/ts/image.ts
+++ b/src/ts/image.ts
@@ -8,7 +8,7 @@ import type { PREDEFINED } from '../types/internal';
 import { BASEPATH, BASEPATH_V5, BASEPATH_V5_EU, DEFAULT_INFO, DEMO_IDS } from './globals';
 import { Camera } from './camera';
 import { readable, writable, get } from 'svelte/store';
-import { createGUID, deepCopy, fetchInfo, fetchJson, getIdVal, getLocalData, idIsV5, isFetching, loadSerialTour, once, sanitizeAsset, sanitizeImageData, sanitizeMarker } from './utils';
+import { createGUID, deepCopy, fetchInfo, fetchJson, getIdVal, getLocalData, idIsV5, isFetching, loadSerialTour, once, sanitizeImageData, sanitizeMarker } from './utils';
 import { State } from './state';
 import { archive } from './archive';
 


### PR DESCRIPTION
Dit is de huidige staat van het 'sanitize asset src' gebeuren. Ik heb het geimplementeerd als een simpele search-replace in de src van een asset obv een lookup object. Uiteindelijk toch wel in de 'sanitization' stap gedaan omdat het logisch voelt en het zo tenminste toch op minder plekken hoeft te gebeuren dan als je het vanuit ál die plekken in svelte die een asset src doet!

Ik hoor heel graag of ik hiermee op het juiste pad zit :)