### PR TITLE
Make pauseWhenLargerThan on a video embed work again

### DIFF
--- a/src/svelte/virtual/Embed.svelte
+++ b/src/svelte/virtual/Embed.svelte
@@ -111,7 +111,7 @@
 		if(is360) matrix = mainImage.camera.getMatrix(cX, cY, s, 1, rotX, rotY, rotZ, undefined, scaleX, scaleY).join(',');
 		style = (is360 ? `transform:matrix3d(${matrix});` : `--x:${x}px;--y:${y}px;--s:${scale};`)
 			+ (embed.opacity !== undefined && embed.opacity !== 1 ? `--opacity:${embed.opacity};` : '');
-		if(embed.video?.pauseWhenSmallerThan && width) {
+		if((embed.video?.pauseWhenSmallerThan || embed.video?.pauseWhenLargerThan) && width) {
 			const wasPaused:boolean = paused;
 			paused = shouldPause();
 			if(_vid && printGL && (paused != wasPaused)) {


### PR DESCRIPTION
Ticket: https://trollo.lol/b/N0c5mznm/c/45-support-dont-play-when-larger-than-not-working

Testen:
- Zet het Micrio ID RxsqXov
- De wolken moeten stoppen met bewegen bij inzoomen.
 
De check die ik heb toegevoeg klopt sws wel want we hebben het net nog werkend gezien, maar toen werkte het toch ineens niet meer!

Volgens mij is het issue dat om de een of andere reden deze regel concludeert dat het asset 'small' is:
`	const isSmall = embed.width && embed.height ? embed.width * embed.height < Math.pow(3072,2) : false;`
-> daardoor wordt printGL ook false, isRawVideo ook false, wordt printVideo niet gedraaid, wordt loadVideo niet gedraaid en wordt hij dan dus nooit gepauzeeerd... ofzo. is moeilijk en ik ben dood ＊_＊