### PR TITLE
Feature/improve event attribute types

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,25 @@ searchable Knowledge Base at:
 
 For the npm package `@micrio/client`, see https://www.npmjs.com/package/@micrio/client
 
+## Using the package from React Typescript
+
+In order to use the `@micrio/client` package in a code base which uses React with Typescript, the following code needs to be added in an additional `micrio.d.ts` file.
+This will allow the use of the `<micr-io>` element in a fully type-safe manner.
+
+```tsx
+import type { Models, HTMLMicrioElement } from '@micrio/client';
+
+/** Specific case to support  */
+declare module 'react' {
+  namespace JSX {
+    interface IntrinsicElements {
+      'micr-io': React.DetailedHTMLProps<Models.Attributes.MicrioCustomAttributes & HTMLAttributes<HTMLMicrioElement>, HTMLMicrioElement>;
+    }
+  }
+}
+```
+
+
 ## Getting it running
 
 Make sure you have Node and `pnpm` installed.

--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
 		"publish": "node publish.js",
 		"docs": "npm run create:client --prefix ../Micrio/server/doc.micr.io",
 		"asbuild:untouched": "asc src/wasm/exports.ts --target debug --sourceMap \"http://localhost:2000/build/untouched.wasm.map\" --importMemory",
-		"asbuild:optimized": "asc src/wasm/exports.ts --target release -O3s --converge --runtime stub --disable mutable-globals --disable sign-extension --noExportMemory --noAssert --pedantic --importMemory"
+		"asbuild:optimized": "asc src/wasm/exports.ts --target release -O3s --converge --runtime stub --disable mutable-globals --disable sign-extension --noExportMemory --noAssert --pedantic --importMemory",
+		"typecheck": "tsc"
 	},
 	"keywords": [
 		"micrio"

--- a/src/svelte/common/Controls.svelte
+++ b/src/svelte/common/Controls.svelte
@@ -82,8 +82,8 @@
 	let secondaryPortrait:boolean = $state(false);
 
 	/** Event handler for 'splitscreen-start'. Sets up secondary controls if needed. */
-	function splitStart(e:Event) {
-		const img = (e as CustomEvent).detail as MicrioImage;
+	function splitStart(e:Models.MicrioEventMap['splitscreen-start']) {
+		const img = e.detail;
 		// Only show separate controls for the secondary image if it's interactive (not passive)
 		secondaryPortrait = micrio.canvas.viewport.portrait; // Store orientation for styling
 		if(!img.opts.isPassive) secondaryControls = img;

--- a/src/svelte/common/Gallery.svelte
+++ b/src/svelte/common/Gallery.svelte
@@ -373,9 +373,9 @@
 	}
 
 	/** Handles the end of a pan gesture (or pinch). */
-	function pEnd(e:Event) : void {
+	function pEnd(e:Models.MicrioEventMap['panend']) : void {
 		// If triggered by 'panend' but detail is missing, it means pinch took over, reset panning
-		const d = (e as CustomEvent).detail;
+		const d = e.detail;
 		if(e.type == 'panend' && !d) {
 			panning = false;
 		}

--- a/src/svelte/common/Subtitles.svelte
+++ b/src/svelte/common/Subtitles.svelte
@@ -90,7 +90,7 @@
 	/** Local state variable to store the current media playback time. */
 	let currentTime:number = $state(0);
 	/** Event handler to update `currentTime` based on 'timeupdate' events dispatched by Media.svelte. */
-	const setTime = (e:Event) => currentTime = (e as CustomEvent).detail;
+	const setTime = (e:Models.MicrioEventMap['timeupdate']) => currentTime = e.detail;
 
 	// --- Lifecycle ---
 

--- a/src/svelte/components/Marker.svelte
+++ b/src/svelte/components/Marker.svelte
@@ -505,9 +505,12 @@
 		}
 	}
 
-	/** Handles external position changes (e.g., from Spaces editor). */
+	/**
+	 * Handles external position changes (e.g., from Spaces editor).
+	 * TODO: what event should this be in the MicrioEventMap? It's the 'changed' event of a div!
+	 */
 	function changed(e:Event) {
-		const m = (e as CustomEvent).detail as typeof marker;
+		const m = (e as Models.MicrioEvent<typeof marker>).detail;
 		marker.x = m.x;
 		marker.y = m.y;
 		moved(); // Recalculate position

--- a/src/ts/element.ts
+++ b/src/ts/element.ts
@@ -255,6 +255,18 @@ export class HTMLMicrioElement extends HTMLElement {
 		}
 	}
 
+	// Custom overloads for addEventListener to support fully typed custom Micrio events
+	addEventListener<K extends keyof Models.MicrioEventMap>(type: K, listener: (this: HTMLMicrioElement, ev: Models.MicrioEventMap[K]) => any, options?: boolean | AddEventListenerOptions): void;
+	addEventListener<K extends keyof HTMLElementEventMap>(type: K, listener: (this: HTMLMicrioElement, ev: HTMLElementEventMap[K]) => any, options?: boolean | AddEventListenerOptions): void;
+	addEventListener(type: string, listener: (this: HTMLMicrioElement, ev: Event) => any, options?: boolean | AddEventListenerOptions): void;
+	addEventListener(type: string, listener: EventListener | EventListenerObject, useCapture?: boolean): void { super.addEventListener(type, listener, useCapture); }
+
+	// Custom overloads for removeEventListener to support fully typed custom Micrio events
+	removeEventListener<K extends keyof Models.MicrioEventMap>(type: K, listener: (this: HTMLMicrioElement, ev: Models.MicrioEventMap[K]) => any, options?: boolean | EventListenerOptions): void;
+	removeEventListener<K extends keyof HTMLElementEventMap>(type: K, listener: (this: HTMLMicrioElement, ev: HTMLElementEventMap[K]) => any, options?: boolean | EventListenerOptions): void;
+	removeEventListener(type: string, listener: (this: HTMLMicrioElement, ev: Event) => any, options?: boolean | EventListenerOptions): void;
+	removeEventListener(type: string, listener: EventListener | EventListenerObject, useCapture?: boolean): void { super.removeEventListener(type, listener, useCapture); }
+
 	/** Destroys the Micrio instance, cleans up resources, and removes event listeners. */
 	destroy() : void {
 		this.current.set(undefined); // Clear current image
@@ -348,7 +360,7 @@ export class HTMLMicrioElement extends HTMLElement {
 		// --- Final Setup & Open ---
 		this.keepRendering = !!opts.settings.keepRendering; // Set continuous rendering flag
 		const doOpen = opts.id || opts.gallery || opts.grid; // Check if there's something to open
-		this.events.dispatch('print', opts); // Dispatch 'print' event
+		this.events.dispatch('print', opts as Models.ImageInfo.ImageInfo); // Dispatch 'print' event
 
 		// Handle lazy loading
 		if(opts.settings.lazyload !== undefined && 'IntersectionObserver' in window) {

--- a/src/ts/events.ts
+++ b/src/ts/events.ts
@@ -61,7 +61,7 @@ function cancelPrevent(e:AllEvents){
  * @internal
  * @readonly
  */
-export const UpdateEvents:string[] = [
+export const UpdateEvents:(keyof Models.MicrioEventMap)[] = [
 	'move',
 	'marker-open',
 	'marker-opened',
@@ -237,7 +237,7 @@ export const UpdateEvents:string[] = [
 	 * @param type The event type string.
 	 * @param detail Optional event detail payload.
 	 */
-	dispatch(type:string, detail?:any) : void {
+	dispatch<K extends keyof Models.MicrioEventDetails>(type:K, detail?:Models.MicrioEventDetails[K]) : void {
 		this.micrio.dispatchEvent(new CustomEvent(type, detail !== undefined ? { detail } : undefined))
 	}
 

--- a/src/ts/image.ts
+++ b/src/ts/image.ts
@@ -674,7 +674,7 @@ export class MicrioImage {
 		// Dispatch pre-data event allowing external modification of all loaded data
 		this.wasm.micrio.events.dispatch('pre-data', {
 			[this.id]: d, // Current image data
-			...Object.fromEntries(micIdsUnique.map((id,i) => [id, micData[i]])) // Preloaded linked data
+			...Object.fromEntries(micIdsUnique.map((id,i) => [id, micData[i]!])) // Preloaded linked data
 		});
 
 		// If linked images were already initialized but lacked data, set it now

--- a/src/ts/state.ts
+++ b/src/ts/state.ts
@@ -283,8 +283,8 @@ export namespace State {
 			this.view.subscribe(view => {
 				this._view = view; // Update internal reference
 				const nV = view?.toString(); // Stringify for simple comparison
-				const detail = {image, view}; // Event detail payload
 				if(view && nV && pV != nV) { // If view changed
+					const detail = {image, view}; // Event detail payload
 					pV = nV;
 					const nW = view[2]-view[0], nH = view[3]-view[1]; // Calculate new width/height
 					// Dispatch 'zoom' event if dimensions changed significantly

--- a/src/types/models.ts
+++ b/src/types/models.ts
@@ -1479,4 +1479,98 @@ import type { IconDefinition } from '@fortawesome/free-solid-svg-icons';
 	export type MicrioEventMap = {
 		[K in keyof MicrioEventDetails]: MicrioEvent<MicrioEventDetails[K]>;
 	}
+
+	export namespace Attributes {
+		export interface MicrioCustomAttributes {
+			// General settings
+			/** The image ID */
+			'id'?: string;
+			/** The data language code to use. Default: 'en' */
+			'lang'?: string;
+			/** For custom hosted Micrio images, specify the root URL. Default: Based on image */
+			'data-path'?: string;
+			/** Set this to 'cover' to start the image using the full viewport. Default: undefined */
+			'data-inittype'?: string;
+			/** The user cannot zoom out further than the full viewport. Default: undefined */
+			'data-coverlimit'?: boolean;
+			/** Only start loading the image when it's been scrolled into the user's view. Default: false */
+			'lazyload'?: boolean;
+			/** Do not load any metadata (markers, tours, etc). Default: false */
+			'data-skipmeta'?: boolean;
+			/** Simulate an <img/> element. No logo, loader bar, and no event listeners. Default: false */
+			'data-static'?: boolean;
+			/** Read and write deeplinks to opened tours and markers. Default: null */
+			'data-router'?: string;
+			/** Prevent sending user input as GA Events. Default: true */
+			'data-gtag'?: boolean;
+
+			// Camera controls
+			/** Set the speed factor for camera animations. Default: 1 */
+			'data-camspeed'?: number;
+			/** Can pan outside the image's limits. Default: false */
+			'data-freemove'?: boolean;
+			/** Set the percentage (1=100%) of how far a user can zoom in. Default: 1 */
+			'data-zoomlimit'?: number;
+			/** Set the initial viewport rectangle of the image. Default: [0,0,1,1] */
+			'data-view'?: number[];
+			/** Set focus point of the image, treated as the center in case of image overflows. Default: [0.5, 0.5] */
+			'data-focus'?: number[];
+			/** Keep drawing frames, even if there is no movement. Default: false */
+			'data-keeprendering'?: boolean;
+			/** When turned off, high DPI screens will have its zoom limited to visually 100% of pixel size. Default: true */
+			'data-normalize-dpr'?: boolean;
+
+			// User input
+			/** No event handlers will be set up, and the image will be non-interactive. Default: true */
+			'data-events'?: boolean;
+			/** Use your keyboard to navigate through the image. Default: false */
+			'data-keys'?: boolean;
+			/** Use trackpad/touchscreen pinching for zooming. Default: true */
+			'data-pinch-zoom'?: boolean;
+			/** Use mousewheel/trackpad scrolling for zooming. Default: true */
+			'data-scroll-zoom'?: boolean;
+			/** The user must press CTRL/CMD when zooming with the mousewheel. Default: false */
+			'data-control-zoom'?: boolean;
+			/** Requires the user to use two fingers to pan the image on touch devices. Default: false */
+			'data-two-finger-pan'?: boolean;
+			/** The user cannot zoom at all. Default: true */
+			'data-zooming'?: boolean;
+			/** Use dragging and touch events for panning. Default: true */
+			'data-dragging'?: boolean;
+
+			// User interface
+			/** No HTML UI elements will be printed. Default: true */
+			'data-ui'?: boolean;
+			/** No control buttons will be printed. Default: true */
+			'data-controls'?: boolean;
+			/** Show a fullscreen switching button on supported platforms. Default: true */
+			'data-fullscreen'?: boolean;
+			/** Show a social sharing link menu. Default: false */
+			'data-social'?: boolean;
+			/** The Micrio logo will be hidden. Default: true */
+			'data-logo'?: boolean;
+			/** The optional Organisation logo (top right) will be hidden. Default: true */
+			'data-logo-org'?: boolean;
+			/** No top menu bar will be printed. Default: true */
+			'data-toolbar'?: boolean;
+			/** Show an image info panel with the title and description. Default: false */
+			'data-show-info'?: boolean;
+			/** An interactive minimap will be shown. Default: false */
+			'data-minimap'?: boolean;
+			/** The minimap will always be visible. Default: true */
+			'data-minimap-hide'?: boolean;
+			/** The minimap height in pixels. Default: 160 */
+			'data-minimap-height'?: number;
+			/** The minimap width in pixels. Default: 200 */
+			'data-minimap-width'?: number;
+
+			// Audio
+			/** All audio will be disabled if this attribute is present. */
+			'muted'?: boolean;
+			/** The general sound volume for music/sfx (between 0 and 1). Default: 1 */
+			'volume'?: number;
+			/** Fade music to this volume while other audio plays (between 0 and 1). Default: 0 */
+			'data-mutedvolume'?: number;
+		}
+	}
 }

--- a/src/types/models.ts
+++ b/src/types/models.ts
@@ -2,6 +2,7 @@
 /// <reference types="svelte" />
 
 import type { HTMLMicrioElement } from '../ts/element';
+import type { Grid } from '../ts/grid';
 import type { MicrioImage } from '../ts/image';
 import type { VideoTourInstance } from '../ts/videotour';
 import type { Writable } from 'svelte/store';
@@ -731,7 +732,7 @@ import type { IconDefinition } from '@fortawesome/free-solid-svg-icons';
 			positionalAudio?: Assets.AudioLocation;
 
 			/** Optional function that overrides all behavior */
-			onclick?: (m:Models.ImageData.Marker) => void;
+			onclick?: (m:ImageData.Marker) => void;
 
 			/** Additional options */
 			data?: MarkerData;
@@ -1171,7 +1172,7 @@ import type { IconDefinition } from '@fortawesome/free-solid-svg-icons';
 			/** Custom icon lib */
 			icons?: Assets.Image[];
 			/** Multi-image marker tours */
-			markerTours?: Models.ImageData.MarkerTour[];
+			markerTours?: ImageData.MarkerTour[];
 		}
 
 		export interface WaypointInterface {
@@ -1254,7 +1255,7 @@ import type { IconDefinition } from '@fortawesome/free-solid-svg-icons';
 		)
 
 		/** Virtual ImageInfo extension to support grid logic */
-		export interface GridImage extends Partial<Models.ImageInfo.ImageInfo> {
+		export interface GridImage extends Partial<ImageInfo.ImageInfo> {
 			size: [number, number?];
 			area?: Camera.View;
 			view?: Camera.View;
@@ -1278,7 +1279,7 @@ import type { IconDefinition } from '@fortawesome/free-solid-svg-icons';
 			/** Transition duration in ms */
 			duration?: number;
 			/** Transition animation, defaults to crossfade */
-			transition?: Models.Grid.MarkerFocusTransition;
+			transition?: Grid.MarkerFocusTransition;
 			/** Set the target viewport immediately */
 			noViewAni?: boolean;
 			/** Animate the previously focussed image to this view during exit transition */
@@ -1375,11 +1376,11 @@ import type { IconDefinition } from '@fortawesome/free-solid-svg-icons';
 	export namespace State {
 		/** Popover interface state type */
 		export interface PopoverType {
-			contentPage?: Models.ImageData.Menu;
+			contentPage?: ImageData.Menu;
 			image?: MicrioImage;
-			marker?: Models.ImageData.Marker;
-			markerTour?: Models.ImageData.MarkerTour;
-			gallery?: Models.Assets.Image[];
+			marker?: ImageData.Marker;
+			markerTour?: ImageData.MarkerTour;
+			gallery?: Assets.Image[];
 			galleryStart?: string;
 			showLangSelect?: boolean;
 		}
@@ -1396,5 +1397,86 @@ import type { IconDefinition } from '@fortawesome/free-solid-svg-icons';
 			portrait:boolean;
 		}
 	}
+	
+	export type MicrioEvent<T = any> = Event & { detail: T };
 
+	export interface MicrioEventDetails {
+		// General events
+		'show': HTMLMicrioElement; // The main Micrio image is loaded and fully shown
+		'pre-info': ImageInfo.ImageInfo; // Before the ImageInfo settings are read, this event allows you to alter them
+		'pre-data': { [micrioId: string]: ImageData.ImageData }; // Before the ImageData contents are read, this event allows you to alter it
+		'print': ImageInfo.ImageInfo; // The main Micrio element has initialized and is being printed
+		'load': MicrioImage; // Individual image data is loaded and Micrio will start rendering
+		'lang-switch': string; // The user has switched available languages
+
+		// Camera events
+		'zoom': { image: MicrioImage, view: Camera.View }; // The camera has zoomed
+		'move': { image: MicrioImage, view: Camera.View }; // The camera has moved
+		'draw': void; // A frame has been drawn
+		'resize': DOMRect; // The <micr-io> element was resized
+
+		// User input events
+		'panstart': void; // The user has started panning
+		'panend': {duration: number, movedX: number, movedY: number}; // The user has stopped panning
+		'pinchstart': void; // The user has stopped pinching
+		'pinchend': {duration: number, movedX: number, movedY: number}; // The user has stopped pinching
+
+		// Marker events
+		'marker-open': ImageData.Marker; // A marker has been opened and the camera animation is starting
+		'marker-opened': ImageData.Marker; // A marker has been fully opened and the camera is done, and popup shown
+		'marker-closed': ImageData.Marker; // A marker has been successfully closed
+
+		// Marker and video tours
+		'tour-start': ImageData.Tour; // A tour has been successfully started
+		'tour-stop': ImageData.Tour; // A tour has been successfully stopped
+		'tour-minimize': ImageData.Tour; // A tour's UI interface has automatically minimized
+
+		// Marker Tours
+		'tour-step': ImageData.MarkerTour; // Fires for each marker step in a marker tour
+		'serialtour-play': ImageData.MarkerTour; // A multi-image tour is played/resumed
+		'serialtour-pause': ImageData.MarkerTour; // A multi-image tour is paused
+
+		// Video Tours
+		'videotour-start': ImageData.VideoTour; // A video tour has started from the beginning (can be part of a marker tour)
+		'videotour-stop': ImageData.VideoTour; // A video tour has ended or is aborted (can be part of a marker tour)
+		'videotour-play': void; // A video tour is played or resumed
+		'videotour-pause': void; // A video tour is paused
+		'tour-ended': ImageData.VideoTour; // A video tour has ended
+		'tour-event': ImageData.Event; // When a video tour has custom events, they will be fired like this
+
+		// Main media (video, audio, video tours)
+		'audio-init': void; // The audio controller has been successfully initialized and can play audio
+		'audio-mute': void; // The audio has been muted
+		'audio-unmute': void; // The audio has been unmuted
+		'autoplay-blocked': void; // Fires when there is autoplay audio or video which was disallowed by the browser
+		'media-play': void; // Media has started playing
+		'media-pause': void; // Media has stopped playing
+		'media-ended': void; // Media has ended
+		'timeupdate': number; // A media timeupdate tick
+
+		// Custom page popovers
+		'page-open': ImageData.Menu; // A custom popover page was opened
+		'page-closed': ImageData.Menu; // A custom popover page was closed
+
+		// Album viewing
+		'gallery-show': number; // Triggers on album image change
+
+		// Grid views
+		'grid-init': Grid; // The grid controller has initialized
+		'grid-load': void; // All images in the grid have loaded
+		'grid-layout-set': Grid; // The grid layout has changed
+		'grid-focus': MicrioImage; // The main grid view is activated
+		'grid-blur': void; // The main grid has lost focus, i.e., navigated away
+
+		// Splitscreen views
+		'splitscreen-start': MicrioImage; // Split screen mode has started
+		'splitscreen-stop': MicrioImage; // Split screen mode has stopped
+
+		// Special cases
+		'update': Array<string>; // When there is any user action, this event fires. Deferred and fires at a maximum rate of every 500ms
+	}
+	
+	export type MicrioEventMap = {
+		[K in keyof MicrioEventDetails]: MicrioEvent<MicrioEventDetails[K]>;
+	}
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,7 +2,8 @@
 	"extends": "@tsconfig/svelte/tsconfig.json",
 	"compilerOptions": {
 		"strict": true,
-		"target": "ES2020"
+		"target": "ES2020",
+		"noEmit": true
 	},
 	"include": [
 		"src/svelte/Main.svelte",


### PR DESCRIPTION
## Description of changes

In the process of building the new Micrio.Templates repo, I encountered some things about the micrio client typescript defs, notably for event listeners and the runtime attributes, that I would like to be more specific/watertight in the lib.

Changes:
- Give the HTMLMicrioElement.addEventListener / removeEventListener very nice autocompletion, autofilling the micrio custom event types and auto-typing the event.detail property.
- Through doing this (I generated based on doc.micr.io), I encountered some inconsistencies between the docs and the reality of the code. A nice sanity check! see ⊕ for the additional changes I made to make typescript compile again. Also note that in case you agree with all these changes, we'll also need to update them in doc.micr.io 😌
- For integrating the `<micr-io>` element in React, a certain global type needs to be declared. Ideally I'd like to one day have a package named something like `@micrio/client-react`, but for now I at least wanted it to be clear from the README how to use this package with React.
- In order for this React thing to fully blossom, I also exposed the Micrio runtime attributes in the models, so React Typescript won't complain about these 'unknown' attributes. Here I also found two attributes that are not in the docs but are read by the micr-io element: see ※ Again these should also be added to doc.micr.io in the future.

Recommended to go through the code commit-by-commit.

⊕
bij het integreren van de gedetailleerde event-types in micrio codebase opgevallen:
- element.ts r368: this.events.dispatch('print', opts as Models.ImageInfo.ImageInfo); // Dispatch 'print' event
	opts is eigenlijk een partial imageinfo gaat dat goed?
- events.ts r485: if(!noDispatch) this.dispatch('panend', !e ? undefined : { … }
	daar wordt iets meegegeven voor 'panend' terwijl in docs staat dat panend event niks return als detail. heb dat nu aangepast in de declaratie.
	trouwens ik zie in Gallery.svelte dat bij pinchend dit ook wordt meegegeven, dit ook geupdate in de declaratie.
- er stond nog geen 'pinchstart' event in de docs terwijl deze wel wordt gedispatched, heb dat nu iig in e declaratie gezet.
- state.ts r296: m.events.dispatch('move', detail);
	in de docs staat dat voor het 'move' event alleen de view wordt meegegeven, maar gedispatched wordt hetzelfde object als bij 'zoom'. heb dit voor nu iig in de declaratie aangepast om te kloppen met wat daadwerkelijk wordt gedispatched.
- grid.ts r519: this.micrio.events.dispatch('grid-layout-set', this);
	hier is te zien dat het grid zelf wordt meegegeven bij het 'grid-layout-set' event terwijl in de docs staat dat er niks wordt meegegeven. dit door nu in de declaratie geupdate.
- grid.ts r749: m.events.dispatch('grid-focus', img);
	hier is te zien dat de MicrioImage wordt meegegeven bij het 'grid-focus' event terwijl in de docs staat dat er niks wordt meegegeven. dit voor nu in de declaratie geupdate.
- image.ts r676: this.wasm.micrio.events.dispatch('pre-data', { … }
	hier wordt niet een ImageInfo meegegeven zoals de docs zeggen, maar een object met per ID de ImageData voor dat ID! Heb dit voor nu in de declaratie aangepast om met de dispatch te kloppen.

※
Over de nieuwe custom attributes: deze staan niet in de micrio docs:
- 'data-grid'?: Grid;
- 'data-limited'?: boolean;

## How to validate the changes
- Build the micrio client and use the micrio.d.ts and micrio.min.js file in another project that uses typescript
- In that other project, you should still be able to do `myMicrioHtmlElement.addEventListener` and get beautiful autocompletion for both the micrio custom events and of course the regular HTML events.

## ✅ Definition of Done

This checklist helps with risk management during software development. It is not a mandatory list to fully check off, but a basis for thinking about quality, safety, and best practices. Feel free to adapt it for your own project — as long as the risks are consciously managed.

### 📄 Documentation & Knowledge Sharing

- [ ] Changes are documented in the code and/or `README.md`
- [ ] Relevant Notion pages are updated

### 🧪 Testing & Quality

- [ ] Changes are covered by unit/integration/end-to-end tests
- [ ] GitHub Actions (CI/CD) pass successfully
- [ ] Reviewer has tested and verified the changes locally

### 📊 Monitoring & Performance

- [ ] Relevant metrics (e.g. in Datadog) are added or updated
- [ ] Performance and scalability have been considered and tested if needed

### 🔐 Security & Privacy

- [ ] The changes comply with our [Secure software development policy](https://www.notion.so/q42/12-Secure-software-development-policy-3be5262f736c4a2a854fa2543d90c8be?pvs=4)
- [ ] No personal data or privacy-sensitive information is affected
- [ ] Input validation, authentication, and authorization are properly handled

### 🧩 Traceability & Readiness

- [ ] A Jira ticket is linked, and the ticket number is in the PR title (e.g. `[R2025-1234] Meaningful title`)
- [ ] No unresolved `TODO`s remain in the code (unless followed up with a Jira ticket)

### 🤝 Review & Collaboration

- [ ] Code is reviewed by at least one team member
- [ ] Merge responsibility and timing are agreed upon
- [ ] Team members are informed (e.g. via Slack or daily stand-up)
