### PR TITLE
Ultimate bugfix of ultimateness

### DIFF
--- a/src/wasm/camera.ani.ts
+++ b/src/wasm/camera.ani.ts
@@ -238,7 +238,7 @@ export default class Ani {
 		this.omniStartIdx = this.canvas.activeImageIdx;
 		this.omniDelta = 0;
 		// If a target omni index is provided and different from current
-		if(!isNaN(omniIdx) && omniIdx >= 0 && omniIdx != this.omniStartIdx) {
+		if(!isNaN(omniIdx) && omniIdx > 0 && omniIdx != this.omniStartIdx) {
 			// Calculate shortest rotation delta (wrapping around)
 			this.omniDelta = omniIdx - this.omniStartIdx;
 			if(this.omniDelta < -numPerLayer/2) this.omniDelta += numPerLayer;


### PR DESCRIPTION
Ticket: https://trollo.lol/b/N0c5mznm/c/172-bugfix-gallery-viewer

## Description of changes

Okeeeey ik ben er eindelijk uit met die "Bugfix gallery viewer" en het is een oneliner!

De reden dat ik het lokaal niet gereproduceerd kreeg was dat ik totaal niet realiseerde dat je telkens de asbuild moet draaien! En dan een heel avontuur met soort gebeund bisect-achtige flow later heb ik kunnen pinpointen in welke commit op welke regel het fout is gegaan: namelijk in die commit van Gemini die van alles ging documenteren en kleine bugfixjes ging doen, heeft de AI ook net heel geniepig een ＞ in een ＞＝ veranderd, wat de code blijkbaar net een omni-specifiek blok in laat slaan waar de duration van de animated camera.toView() wordt veranderd en andere wacky dingen. Eerlijk gezegd snap ik niet volledig waarom dit het precies fixt but it's okay want het doet het iig weer! :)

## How to validate the changes

- Draai de asbuild:optimized
- Zet in de index.html een micrio met gallery-viewer, bijv `<micr-io data-gallery="esgZB,960,1280,;pRiMP,960,1280,;xnRwQ,985,1200,,p" data-path="https://micrio.vangoghmuseum.nl/micrio/" data-start="esgZB"></micr-io>`
- npm run dev en check dat de gallery het nu weer doet
