### PR TITLE
Feature/new viewports global

### DIFF
--- a/index.html
+++ b/index.html
@@ -50,11 +50,13 @@
 		Basic test image: dzzLm
 		Omni image: QgjdoCK
 		Omni image with layers: VVxoPCb / GPjAGL
-		360 tour: ZnaHJK
+		360 tour: ZnaHJK / WkdtYs / OJqMYL
 		Embedded video: SUeqOX
 		Serial multi-image tour: ojvqWXd
+		360 poppenhuis: ulNEVz
+		360 hi-res: mLOarF
 	-->
-	<micr-io id="uLNEVz" datxa-embeds-inside-gl="false" data-skipmeta></micr-io>
+	<micr-io id="ZnaHJK" datxa-embeds-inside-gl="false" data-skipmeta></micr-io>
 
 	<!-- Test image with all types of markers -->
 	<!-- <micr-io id="vsmQN" lang="nl" data-camspeed="4" data-path="https://micrio.vangoghmuseum.nl/micrio/"></micr-io> -->

--- a/index.html
+++ b/index.html
@@ -56,7 +56,7 @@
 		360 poppenhuis: ulNEVz
 		360 hi-res: mLOarF
 	-->
-	<micr-io id="ZnaHJK" datxa-embeds-inside-gl="false" data-skipmeta></micr-io>
+	<micr-io id="dzzLm" datxa-embeds-inside-gl="false" datxa-skipmeta></micr-io>
 
 	<!-- Test image with all types of markers -->
 	<!-- <micr-io id="vsmQN" lang="nl" data-camspeed="4" data-path="https://micrio.vangoghmuseum.nl/micrio/"></micr-io> -->
@@ -87,6 +87,10 @@
 		// Put any pre-data init hooks here
 		micrio.addEventListener('pre-data', e => {
 		});
+
+		function fly() {
+			micrio.$current.camera.flyToView({centerX:.4,centerY:.4,width:.2,height:.2})
+		}
 
 	</script>
 </body>

--- a/index.html
+++ b/index.html
@@ -50,13 +50,13 @@
 		Basic test image: dzzLm
 		Omni image: QgjdoCK / HvoNSNV
 		Omni image with layers: VVxoPCb / GPjAGL
-		360 tour: ZnaHJK / WkdtYs / OJqMYL
+		360 tour: ZnaHJK / WkdtYs / OJqMYL / EaouKa / fmxpBY
 		Embedded video: SUeqOX
 		Serial multi-image tour: ojvqWXd / JXflr
 		360 poppenhuis: ulNEVz
 		360 hi-res: mLOarF
 	-->
-	<micr-io id="mLOarF" daxta-embeds-inside-gl="true" datxa-skipmeta daxta-cluster-markers></micr-io>
+	<micr-io id="EaouKa" daxta-embeds-inside-gl="true" datxa-skipmeta daxta-cluster-markers></micr-io>
 
 	<!-- Test image with all types of markers -->
 	<!-- <micr-io id="vsmQN" lang="nl" data-camspeed="4" data-path="https://micrio.vangoghmuseum.nl/micrio/"></micr-io> -->

--- a/index.html
+++ b/index.html
@@ -48,15 +48,15 @@
 <body>
 	<!-- DEMO IDs
 		Basic test image: dzzLm
-		Omni image: QgjdoCK
+		Omni image: QgjdoCK / HvoNSNV
 		Omni image with layers: VVxoPCb / GPjAGL
 		360 tour: ZnaHJK / WkdtYs / OJqMYL
 		Embedded video: SUeqOX
-		Serial multi-image tour: ojvqWXd
+		Serial multi-image tour: ojvqWXd / JXflr
 		360 poppenhuis: ulNEVz
 		360 hi-res: mLOarF
 	-->
-	<micr-io id="dzzLm" datxa-embeds-inside-gl="false" datxa-skipmeta></micr-io>
+	<micr-io id="mLOarF" daxta-embeds-inside-gl="true" datxa-skipmeta daxta-cluster-markers></micr-io>
 
 	<!-- Test image with all types of markers -->
 	<!-- <micr-io id="vsmQN" lang="nl" data-camspeed="4" data-path="https://micrio.vangoghmuseum.nl/micrio/"></micr-io> -->

--- a/src/svelte/common/Gallery.svelte
+++ b/src/svelte/common/Gallery.svelte
@@ -186,7 +186,7 @@
 		if(changed) frameChanged(); // Trigger actions needed when the frame changes
 
 		if(!isSwitch) { // For swipe galleries (not switch/omni)
-			const cv = camera.getView() as Models.Camera.View; // Current camera view
+			const cv = camera.getViewLegacy() as Models.Camera.View; // Current camera view
 			const v = pages[i]; // Target page view
 			// Determine if animation is needed
 			const animate = inited && ((zoomedOut && !panning) || changed || ((cv[0] < v[0]) !== (cv[2] > v[2]))); // Animate if zoomed out, page changed, or crossing page boundary

--- a/src/svelte/common/Gallery.svelte
+++ b/src/svelte/common/Gallery.svelte
@@ -387,7 +387,7 @@
 	/** Stores the index of the page closest to the current view center during panning. */
 	let closestIdx:number;
 	/** Updates the `closestIdx` based on the current view during panning. */
-	function moved(v:Models.Camera.View360|undefined) : void {
+	function moved(v:Models.Camera.View|undefined) : void {
 		if(!v) return;
 
 		const c = v.centerX; // Current view center X

--- a/src/svelte/common/Gallery.svelte
+++ b/src/svelte/common/Gallery.svelte
@@ -113,7 +113,7 @@
 	// --- Page Layout Calculation ---
 
 	/** Array storing the calculated view rectangle for each page/spread. */
-	const pages:Models.Camera.View[] = [];
+	const pages:Models.Camera.ViewRect[] = [];
 	/** Array mapping page index to the original image index(es) it contains. */
 	const pageIdxes:number[][] = [];
 
@@ -186,7 +186,7 @@
 		if(changed) frameChanged(); // Trigger actions needed when the frame changes
 
 		if(!isSwitch) { // For swipe galleries (not switch/omni)
-			const cv = camera.getViewLegacy() as Models.Camera.View; // Current camera view
+			const cv = camera.getViewLegacy() as Models.Camera.ViewRect; // Current camera view
 			const v = pages[i]; // Target page view
 			// Determine if animation is needed
 			const animate = inited && ((zoomedOut && !panning) || changed || ((cv[0] < v[0]) !== (cv[2] > v[2]))); // Animate if zoomed out, page changed, or crossing page boundary
@@ -282,7 +282,7 @@
 	// --- Utility Functions ---
 
 	/** Applies view limits, potentially allowing horizontal overflow if zoomed out. */
-	function limit(a:Models.Camera.View, forceArea:boolean) : void {
+	function limit(a:Models.Camera.ViewRect, forceArea:boolean) : void {
 		zoomedOut = camera.isZoomedOut();
 		// If zoomed out and not forcing area, allow horizontal overflow (-1 to 2)
 		camera.setLimit(!forceArea && zoomedOut ? [-1, a[1], 2, a[3]] : a);
@@ -387,14 +387,14 @@
 	/** Stores the index of the page closest to the current view center during panning. */
 	let closestIdx:number;
 	/** Updates the `closestIdx` based on the current view during panning. */
-	function moved(v:Models.Camera.View|undefined) : void {
+	function moved(v:Models.Camera.View360|undefined) : void {
 		if(!v) return;
 
-		const c = v[0] + (v[2]-v[0]) / 2; // Current view center X
+		const c = v.centerX; // Current view center X
 		// Calculate a score for each page based on distance and visibility
 		const distances = pages.map((a, i) => {
 			const fromCenter = (1 - Math.min(Math.abs(c - a[0]),Math.abs(c - a[2]))); // Proximity to center
-			const inView = Math.max(0, (Math.min(v[2],a[2])-Math.max(v[0],a[0])) / (a[2]-a[0])); // Visibility percentage
+			const inView = Math.max(0, (Math.min(c+v.width/2,a[2])-Math.max(c-v.width/2,a[0])) / (a[2]-a[0])); // Visibility percentage
 			return fromCenter * inView * (1-Math.abs(currentPage-i)*.1); // Combine scores, penalize distance from current
 		});
 

--- a/src/svelte/components/Marker.svelte
+++ b/src/svelte/components/Marker.svelte
@@ -181,17 +181,15 @@
 			// Zoom into the cluster's bounding box
 			if(marker.view && $current?.$info) {
 				const currentScale = $current.camera.getScale();
-				// Add margin based on pixel size / image size * scale
-				const margin = [
-					20 / $current.$info.width * currentScale,
-					20 / $current.$info.height * currentScale
-				];
-				image.camera.flyToView([
-					marker.view[0] - margin[0],
-					marker.view[1] - margin[1],
-					marker.view[2] + margin[0],
-					marker.view[3] + margin[1]
-				], {area: image.opts?.area, limitZoom: true});
+				image.camera.flyToView(marker.view, {
+					area: image.opts?.area,
+					limitZoom: true,
+					// Add margin based on pixel size / image size * scale
+					margin: [
+						20 / $current.$info.width * currentScale,
+						20 / $current.$info.height * currentScale
+					]
+				});
 			}
 		}
 		// Standard marker: set as the active marker for the image
@@ -270,15 +268,14 @@
 		if(immediatelyStartMyTourAtBeginning) delete _meta.gridAction; // Temporarily remove grid action
 
 		// Fly camera to marker view, unless it's a video tour marker or grid view marker
-		const hasView360 = marker.view360 && image.is360;
-		const hasView = marker.view && !hasView360; // view360 takes precedence when both exist
+		const hasView = marker.view;
 		
-		if(!immediatelyStartMyTourAtBeginning && (hasView360 || hasView) && !data.noAnimate && !marker.videoTour && !_meta.gridView) {
+		if(!immediatelyStartMyTourAtBeginning && hasView && !data.noAnimate && !marker.videoTour && !_meta.gridView) {
 			if(openOnInit) { // If opened on init, set view directly
-				image.camera.setView(marker.view360 || marker.view!, {area: image.opts?.area});
+				image.camera.setView(marker.view!, {area: image.opts?.area});
 				open(); // Proceed to open content
 			} else { // Otherwise, animate
-					const flyPromise = image.camera.flyToView(marker.view360 || marker.view!, {
+					const flyPromise = image.camera.flyToView(marker.view!, {
 						omniIndex, // Pass omni index if applicable
 						noTrueNorth: true, // Don't correct true north during marker fly-to
 						area: image.opts?.area,

--- a/src/svelte/components/Minimap.svelte
+++ b/src/svelte/components/Minimap.svelte
@@ -9,6 +9,7 @@
 
 	import type { HTMLMicrioElement } from '../../ts/element';
 	import type { MicrioImage } from '../../ts/image';
+    import { viewRawToView360 } from '../../ts/utils';
 	import type { Models } from '../../types/models';
 
 	import { onMount, getContext, } from 'svelte';
@@ -110,7 +111,8 @@
 	// --- Drawing Function ---
 
 	/** Draws the minimap content (thumbnail and viewport indicator). */
-	function draw(area:Models.Camera.View|undefined): void{ // `area` is the current view from the image state store
+	function draw(_area:Models.Camera.ViewRect|undefined): void{ // `area` is the current view from the image state store
+		const area = viewRawToView360(_area);
 		if(!area || !_ctx) return; // Exit if no view or context
 		moved(); // Update hidden state based on activity
 
@@ -143,10 +145,10 @@
 		else { // Draw rectangle for 2D view
 			zoomedOut = camera.isZoomedOut(); // Update zoomedOut state
 			_ctx.rect(
-				Math.floor(area[0]*width), // x
-				Math.floor(area[1]*height), // y
-				Math.ceil((area[2]-area[0])*width), // width
-				Math.ceil((area[3]-area[1])*height) // height
+				Math.floor((area.centerX-area.width/2)*width), // x
+				Math.floor((area.centerY-area.height/2)*height), // y
+				Math.ceil(area.width*width), // width
+				Math.ceil(area.height*height) // height
 			);
 		}
 

--- a/src/svelte/components/Minimap.svelte
+++ b/src/svelte/components/Minimap.svelte
@@ -85,7 +85,7 @@
 	 * Calculates rectangles representing the current 360 viewport for minimap display.
 	 * 
 	 * This replaces the previous getPoly() approach that sampled screen edges and tried to handle
-	 * wrapping manually. The new approach directly converts the Models.Camera.View360 to proper
+	 * wrapping manually. The new approach directly converts the Models.Camera.View to proper
 	 * 2D rectangles, correctly handling:
 	 * 
 	 * - Longitude wrapping (views crossing 180°/-180° boundary)
@@ -95,7 +95,7 @@
 	 * @param area The current camera view in the new {centerX, centerY, width, height} format
 	 * @returns Array of rectangles to draw (1 for normal views, 2 for wrapped views)
 	 */
-	function get360ViewRects(area: Models.Camera.View360): ViewRect[] {
+	function get360ViewRects(area: Models.Camera.View): ViewRect[] {
 		const rects: ViewRect[] = [];
 		
 		// Get the basic rectangle from the camera view
@@ -161,7 +161,7 @@
 	// --- Drawing Function ---
 
 	/** Draws the minimap content (thumbnail and viewport indicator). */
-	function draw(area:Models.Camera.View360|undefined): void{ // `area` is the current view from the image state store
+	function draw(area:Models.Camera.View|undefined): void{ // `area` is the current view from the image state store
 		if(!area||!_ctx) return; // Exit if no view or context
 		moved(); // Update hidden state based on activity
 
@@ -261,7 +261,7 @@
 			
 			if (dragViewDimensions) {
 				// Create new view with updated center but preserved dimensions from drag start
-				const newView: Models.Camera.View360 = {
+				const newView: Models.Camera.View = {
 					centerX: x,
 					centerY: y,
 					width: dragViewDimensions.width,

--- a/src/svelte/components/Minimap.svelte
+++ b/src/svelte/components/Minimap.svelte
@@ -9,7 +9,6 @@
 
 	import type { HTMLMicrioElement } from '../../ts/element';
 	import type { MicrioImage } from '../../ts/image';
-    import { viewRawToView360 } from '../../ts/utils';
 	import type { Models } from '../../types/models';
 
 	import { onMount, getContext, } from 'svelte';
@@ -111,9 +110,8 @@
 	// --- Drawing Function ---
 
 	/** Draws the minimap content (thumbnail and viewport indicator). */
-	function draw(_area:Models.Camera.ViewRect|undefined): void{ // `area` is the current view from the image state store
-		const area = viewRawToView360(_area);
-		if(!area || !_ctx) return; // Exit if no view or context
+	function draw(area:Models.Camera.View360|undefined): void{ // `area` is the current view from the image state store
+		if(!area||!_ctx) return; // Exit if no view or context
 		moved(); // Update hidden state based on activity
 
 		_ctx.clearRect(0,0, width, height); // Clear the canvas

--- a/src/svelte/components/Waypoint.svelte
+++ b/src/svelte/components/Waypoint.svelte
@@ -136,7 +136,11 @@
 			1, // Radius (seems fixed at 1 here?)
 			coords.rotX,
 			coords.rotY,
-			coords.rotZ
+			coords.rotZ,
+			0,
+			1,
+			1,
+			true
 		).join(',');
 	}
 

--- a/src/svelte/virtual/AudioController.svelte
+++ b/src/svelte/virtual/AudioController.svelte
@@ -189,11 +189,10 @@
 				viewUnsub = image.state.view.subscribe(
 					v => { // View store subscription callback
 						if(!v) return;
-						const w = v[2]-v[0], h = v[3]-v[1]; // Calculate view width/height
 						// Calculate depth factor based on zoom level (closer to 1 when zoomed in)
 						const d = Math.max(0, 1.05 - image.camera.getScale());
 						// Update listener position based on view center and depth
-						moved(v[0]+w/2, v[1]+h/2, d * (is360 ? 1 : 1.5)); // Apply different depth scaling for 2D/360
+						moved(v.centerX, v.centerY, d * (is360 ? 1 : 1.5)); // Apply different depth scaling for 2D/360
 					}
 				);
 			}

--- a/src/svelte/virtual/Embed.svelte
+++ b/src/svelte/virtual/Embed.svelte
@@ -19,7 +19,7 @@
 
 	import { onMount, getContext } from 'svelte';
 	import { MicrioImage } from '../../ts/image';
-	import { once, createGUID, Browser } from '../../ts/utils';
+	import { once, createGUID, Browser, View } from '../../ts/utils';
 	import { GLEmbedVideo } from '../../ts/embedvideo'; // Handles WebGL video rendering
 
 	import Media from '../components/Media.svelte'; // Reusable media player component
@@ -98,10 +98,10 @@
 	const hrefBlankTarget = href && embed.clickTargetBlank;
 
 	// --- Positioning State (updated by `moved`) ---
-	let w:number = a[2]-a[0]; // Relative width
-	let h:number = a[3]-a[1]; // Relative height
-	let cX:number = a[0] + w / 2; // Center X
-	let cY:number = a[1] + h / 2; // Center Y
+	let w:number = a.width; // Relative width
+	let h:number = a.height; // Relative height
+	let cX:number = a.centerX; // Center X
+	let cY:number = a.centerY; // Center Y
 	let s:number = embed.scale || 1; // Embed scale
 	let rotX:number = embed.rotX??0; // X Rotation
 	let rotY:number = embed.rotY??0; // Y Rotation
@@ -116,12 +116,12 @@
 	function readPlacement() : void {
 		const a = embed.area;
 		// Handle 360 wrap-around for area coordinates
-		if(is360 && a[0] > a[2]) a[0]--;
+		//if(is360 && a[0] > a[2]) a[0]--;
 		// Recalculate dimensions and center
-		w = a[2]-a[0];
-		h = a[3]-a[1];
-		cX = a[0] + w / 2;
-		cY = a[1] + h / 2;
+		w = a.width;
+		h = a.height;
+		cX = a.centerX;
+		cY = a.centerY;
 		// Update scale and rotation values from embed data
 		s = embed.scale || 1;
 		rotX = embed.rotX??0;
@@ -251,9 +251,10 @@
 	function printInsideGL() : void {
 		// Determine initial opacity (use 0.01 if hidden when paused to ensure it renders initially)
 		const opacity = embed.hideWhenPaused ? 0.01 : embed.opacity ?? 1;
+		const area = View.toLegacy(embed.area)!;
 		if(image && image.ptr >= 0) { // If MicrioImage instance already exists (e.g., from previous state)
 			// Update its placement and fade it in
-			image.camera.setArea(embed.area);
+			image.camera.setArea(area);
 			image.camera.setRotation(embed.rotX, embed.rotY, embed.rotZ);
 			wasm.fadeImage(image.ptr, opacity);
 		}
@@ -272,7 +273,7 @@
 				settings: {
 					_360: { rotX, rotY, rotZ } // Pass rotation settings
 				},
-			}, embed.area, { opacity, asImage: false }); // Pass area, initial opacity
+			}, area, { opacity, asImage: false }); // Pass area, initial opacity
 		}
 
 		// If it's a WebGL video, initialize the GLEmbedVideo handler once visible

--- a/src/svelte/virtual/Markers.svelte
+++ b/src/svelte/virtual/Markers.svelte
@@ -12,7 +12,7 @@
 	import type { Models } from '../../types/models';
 
 	import { onMount, setContext, tick } from 'svelte';
-	import { limitView, once } from '../../ts/utils'; // Import utilities
+	import { clone, limitView, once } from '../../ts/utils'; // Import utilities
 
 	// Component imports
 	import Marker from '../components/Marker.svelte';
@@ -79,7 +79,7 @@
 			// no view is already stored, it's not a hidden marker, and it has a target view.
 			if(typeof marker != 'string' && !image.openedView && !marker.noMarker && marker.view) {
 				// Don't store view if currently in a tour (handled by tour logic)
-				image.openedView = micrio.state.$tour ? undefined : image.state.$view?.slice(0);
+				image.openedView = micrio.state.$tour ? undefined : clone(image.state.$view);
 			}
 		} else if(image.openedView && !micrio.state.$tour) { // Marker is being closed, view was stored, and not in a tour
 			// After a tick (to allow state updates), fly back to the stored view
@@ -173,20 +173,21 @@
 		// Generate cluster marker data objects from the groups
 		clusterMarkers=S.map(c=>c.filter((n,i)=>c.indexOf(n)==i)) // Deduplicate indices within each cluster
 			.map((c,v:any)=>({ // Map cluster indices to a MarkerData object
-			title:c.length+'', // Cluster title is the number of markers
-			type:'cluster',
-			// Calculate bounding box view for the cluster
-			view:v=[0,1,2,3].map(i=>(i<2?Math.min:Math.max)( // 0,1=min(x0,y0); 2,3=max(x1,y1)
-				...c.map(j => q[j].view?.[i] ?? (i%2==0?q[j].x:q[j].y)) // Use marker view if available, else use x/y
-			)),
-			// Calculate cluster center based on bounding box
-			x:v[0]+(v[2]-v[0])/2,
-			y:v[1]+(v[3]-v[1])/2,
-			id:''+c, // Use concatenated indices as ID (might be unstable?)
-			data:{},
-			popupType:'none', // Clusters don't open popups
-			tags:[]
-		}));
+				title:c.length+'', // Cluster title is the number of markers
+				type:'cluster',
+				// Calculate bounding box view for the cluster
+				view:v=[0,1,2,3].map(i=>(i<2?Math.min:Math.max)( // 0,1=min(x0,y0); 2,3=max(x1,y1)
+					...c.map(j => q[j].view?.[i] ?? (i%2==0?q[j].x:q[j].y)) // Use marker view if available, else use x/y
+				)),
+				// Calculate cluster center based on bounding box
+				x:v[0]+(v[2]-v[0])/2,
+				y:v[1]+(v[3]-v[1])/2,
+				id:''+c, // Use concatenated indices as ID (might be unstable?)
+				data:{},
+				popupType:'none', // Clusters don't open popups
+				tags:[]
+			})
+		);
 	};
 
 	// --- Fancy Side Label Logic (Omni) ---

--- a/src/svelte/virtual/Markers.svelte
+++ b/src/svelte/virtual/Markers.svelte
@@ -112,7 +112,7 @@
 	let fancyLabels:boolean = $state(false);
 
 	/** Recalculates marker container size/position based on viewport changes (for clustering). */
-	const resize = (v:Models.Camera.View) => (v=v?.map(f => Math.round(f*100)/100)) && (markerStyle = [...cssVars,
+	const resize = (v:Models.Camera.ViewRect) => (v=v?.map(f => Math.round(f*100)/100)) && (markerStyle = [...cssVars,
 		v[0] ? `left: ${v[0]}px` : null,
 		v[1] ? `top: ${v[1]}px` : null,
 		`width: ${v[2]}px`,

--- a/src/svelte/virtual/Markers.svelte
+++ b/src/svelte/virtual/Markers.svelte
@@ -171,23 +171,31 @@
 			}
 		}
 		// Generate cluster marker data objects from the groups
-		clusterMarkers=S.map(c=>c.filter((n,i)=>c.indexOf(n)==i)) // Deduplicate indices within each cluster
-			.map((c,v:any)=>({ // Map cluster indices to a MarkerData object
-				title:c.length+'', // Cluster title is the number of markers
-				type:'cluster',
-				// Calculate bounding box view for the cluster
-				view:v=[0,1,2,3].map(i=>(i<2?Math.min:Math.max)( // 0,1=min(x0,y0); 2,3=max(x1,y1)
-					...c.map(j => q[j].view?.[i] ?? (i%2==0?q[j].x:q[j].y)) // Use marker view if available, else use x/y
-				)),
-				// Calculate cluster center based on bounding box
-				x:v[0]+(v[2]-v[0])/2,
-				y:v[1]+(v[3]-v[1])/2,
-				id:''+c, // Use concatenated indices as ID (might be unstable?)
-				data:{},
-				popupType:'none', // Clusters don't open popups
-				tags:[]
-			})
-		);
+		clusterMarkers = S.map(c => c.filter((n, i) => c.indexOf(n) === i)) // Deduplicate indices within each cluster
+			.map((c) => {
+				const minX = Math.min(...c.map(j => q[j].view ? q[j].view.centerX - q[j].view.width / 2 : q[j].x));
+				const maxX = Math.max(...c.map(j => q[j].view ? q[j].view.centerX + q[j].view.width / 2 : q[j].x));
+				const minY = Math.min(...c.map(j => q[j].view ? q[j].view.centerY - q[j].view.height / 2 : q[j].y));
+				const maxY = Math.max(...c.map(j => q[j].view ? q[j].view.centerY + q[j].view.height / 2 : q[j].y));
+				const centerX = (minX + maxX) / 2;
+				const centerY = (minY + maxY) / 2;
+				return {
+				title: c.length + '',
+				type: 'cluster',
+				view: {
+					centerX,
+					centerY,
+					width: maxX - minX,
+					height: maxY - minY
+				},
+				x: centerX,
+				y: centerY,
+				id: c.sort((a,b) => a - b).join(','),
+				data: {},
+				popupType: 'none',
+				tags: []
+				};
+			});
 	};
 
 	// --- Fancy Side Label Logic (Omni) ---

--- a/src/svelte/virtual/Markers.svelte
+++ b/src/svelte/virtual/Markers.svelte
@@ -79,7 +79,7 @@
 			// no view is already stored, it's not a hidden marker, and it has a target view.
 			if(typeof marker != 'string' && !image.openedView && !marker.noMarker && marker.view) {
 				// Don't store view if currently in a tour (handled by tour logic)
-				image.openedView = micrio.state.$tour ? undefined : clone(image.state.$view);
+				image.openedView = micrio.state.$tour && !('steps' in micrio.state.$tour) ? undefined : clone(image.state.$view);
 			}
 		} else if(image.openedView && !micrio.state.$tour) { // Marker is being closed, view was stored, and not in a tour
 			// After a tick (to allow state updates), fly back to the stored view
@@ -96,8 +96,15 @@
 	}
 
 	// Clear stored opened view if a tour starts that keeps the last step active
+	let wasMarkerTour:boolean = false;
 	micrioState.tour.subscribe(t => {
-		if(t && 'steps' in t && t.keepLastStep) image.openedView = undefined;
+		if(t && 'steps' in t) {
+			wasMarkerTour = true;
+			if (t.keepLastStep) image.openedView = undefined;
+		} else {
+			if(!t && !image.openedView) image.camera.stop();
+			wasMarkerTour = false;
+		}
 	});
 
 	// --- Styling & Positioning ---

--- a/src/svelte/virtual/Markers.svelte
+++ b/src/svelte/virtual/Markers.svelte
@@ -102,7 +102,7 @@
 			wasMarkerTour = true;
 			if (t.keepLastStep) image.openedView = undefined;
 		} else {
-			if(!t && !image.openedView) image.camera.stop();
+			if(!t && !image.openedView && wasMarkerTour) image.camera.stop();
 			wasMarkerTour = false;
 		}
 	});

--- a/src/svelte/virtual/Tour.svelte
+++ b/src/svelte/virtual/Tour.svelte
@@ -245,7 +245,7 @@
 			for(let i=0;i<_scroller.children.length;i++) if(_scroller.children[i] == el) {
 				const m = data.markers?.find(m => m.id == steps[i].split(',')[0]);
 				// Fly to the marker's view
-				if(m) micrio.$current?.camera.flyToView(m.view as Models.Camera.View).catch(() => {});
+				if(m) micrio.$current?.camera.flyToView(m.view as Models.Camera.View360).catch(() => {});
 				return;
 			}
 		}

--- a/src/svelte/virtual/Tour.svelte
+++ b/src/svelte/virtual/Tour.svelte
@@ -245,7 +245,7 @@
 			for(let i=0;i<_scroller.children.length;i++) if(_scroller.children[i] == el) {
 				const m = data.markers?.find(m => m.id == steps[i].split(',')[0]);
 				// Fly to the marker's view
-				if(m) micrio.$current?.camera.flyToView(m.view as Models.Camera.View360).catch(() => {});
+				if(m) micrio.$current?.camera.flyToView(m.view as Models.Camera.View).catch(() => {});
 				return;
 			}
 		}

--- a/src/ts/camera.ts
+++ b/src/ts/camera.ts
@@ -452,8 +452,9 @@ export class Camera {
 		if (this.image.$settings.omni?.frames) {
 			const numLayers = this.image.$settings.omni.layers?.length ?? 1;
 			const numPerLayer = (this.image.$settings.omni.frames / numLayers);
-			if (opts.omniIndex == undefined && Array.isArray(view) && view[5] !== undefined) {
-				opts.omniIndex = Math.round(mod(view[5] / (Math.PI * 2)) * numPerLayer);
+			if (opts.omniIndex == undefined) {
+				const idx = 'centerX' in view ? view.omniIndex : Array.isArray(view) && view[5] !== undefined ? view[5] : undefined;
+				if(idx !== undefined)opts.omniIndex = Math.round(mod(idx / (Math.PI * 2)) * numPerLayer);
 			}
 			if (opts.omniIndex != undefined) opts.omniIndex = mod(opts.omniIndex, numPerLayer);
 		}

--- a/src/ts/camera.ts
+++ b/src/ts/camera.ts
@@ -364,13 +364,10 @@ export class Camera {
 	 * Sets a rectangular limit for camera navigation within the image.
 	 * @param l The viewport limit rectangle [x0, y0, x1, y1].
 	*/
-	public setLimit(l:Models.Camera.ViewRect) : void {
+	public setLimit(l:Models.Camera.ViewRect|Models.Camera.View360) : void {
 		if (!this.e) return;
-		const lCenterX = (l[0] + l[2]) / 2;
-		const lCenterY = (l[1] + l[3]) / 2;
-		const lWidth = l[2] - l[0];
-		const lHeight = l[3] - l[1];
-		this.e._setLimit(this.image.ptr, lCenterX, lCenterY, lWidth, lHeight);
+		l = View.sanitize(l)!;
+		this.e._setLimit(this.image.ptr, l.centerX, l.centerY, l.width, l.height);
 		this.image.wasm.render();
 	}
 

--- a/src/ts/camera.ts
+++ b/src/ts/camera.ts
@@ -109,8 +109,8 @@ export class Camera {
 		const centerCoords = this.getCoo(0,0); // Get image coordinates at screen center
 
 		// Update center property [x, y, scale]
-		this.center[0] = v[0] + (v[2]-v[0]) / 2;
-		this.center[1] = v[1] + (v[3]-v[1]) / 2;
+		this.center[0] = v[0];
+		this.center[1] = v[1];
 		this.center[2] = centerCoords[2]; // Scale
 
 		// Update 360 orientation [yaw, pitch]

--- a/src/ts/camera.ts
+++ b/src/ts/camera.ts
@@ -316,9 +316,9 @@ export class Camera {
 	 * @param scaleY Optional non-uniform Y scaling.
 	 * @returns The resulting 4x4 matrix as a Float32Array.
 	 */
-	getMatrix(x:number, y:number, scale?:number, radius?:number, rotX?:number, rotY?:number, rotZ?:number, transY?:number, scaleX?:number, scaleY?:number) : Float32Array {
+	getMatrix(x:number, y:number, scale?:number, radius?:number, rotX?:number, rotY?:number, rotZ?:number, transY?:number, scaleX?:number, scaleY?:number, noCorrectNorth?:boolean) : Float32Array {
 		if (!this.e) return new Float32Array(16); // Return identity matrix if Wasm not ready
-		this.e._getMatrix(this.image.ptr, x, y, scale, radius, rotX||0, rotY||0, rotZ||0, transY||0, scaleX??1, scaleY??1);
+		this.e._getMatrix(this.image.ptr, x, y, scale, radius, rotX||0, rotY||0, rotZ||0, transY||0, scaleX??1, scaleY??1, noCorrectNorth);
 		return this._mat; // Return direct buffer reference
 	}
 
@@ -458,7 +458,7 @@ export class Camera {
 			}
 			if (opts.omniIndex != undefined) opts.omniIndex = mod(opts.omniIndex, numPerLayer);
 		}
-		const duration = this.e._flyTo(this.image.ptr, centerX, centerY, width, height, opts.duration ?? -1, opts.speed ?? -1, opts.progress ?? 0, !!opts.isJump, !!opts.limit, !!opts.limitZoom, opts.omniIndex ?? 0, !!opts.noTrueNorth, Enums.Camera.TimingFunction[opts.timingFunction ?? 'ease'], performance.now());
+		const duration = this.e._flyTo(this.image.ptr, centerX, centerY, width, height, opts.duration ?? -1, opts.speed ?? -1, opts.progress ?? 0, !!opts.isJump, !!opts.limit, !!opts.limitZoom, opts.omniIndex ?? 0, !opts.noTrueNorth, Enums.Camera.TimingFunction[opts.timingFunction ?? 'ease'], performance.now());
 		this.image.wasm.render(); // Trigger render loop
 		if (duration == 0) ok(); // Resolve immediately if duration is 0
 		else this.setAniPromises(ok, abort); // Store promise callbacks

--- a/src/ts/camera.ts
+++ b/src/ts/camera.ts
@@ -23,7 +23,7 @@ export class Camera {
 	*/
 	private _view!: Float64Array;
 
-	private readonly view: Models.Camera.View360 = {
+	private readonly view: Models.Camera.View = {
 		centerX: .5,
 		centerY: .5,
 		width: 1,
@@ -148,10 +148,10 @@ export class Camera {
 		y: a[1] + y * (a[3]-a[1])
 	});
 
-	/** Type guard to check if a parameter is a View360 object.
+	/** Type guard to check if a parameter is a View object.
 	 * @internal
 	 */
-	private isView360 = (view: Models.Camera.ViewRect | Models.Camera.View360): view is Models.Camera.View360 => {
+	private isView = (view: Models.Camera.ViewRect | Models.Camera.View): view is Models.Camera.View => {
 		return typeof view === 'object' && !Array.isArray(view) && 
 			'centerX' in view && 'centerY' in view && 'width' in view && 'height' in view;
 	};
@@ -199,7 +199,7 @@ export class Camera {
 	 * Gets the current image view rectangle.
 	 * @returns A copy of the current screen viewport array, or undefined if not initialized.
 	 */
-	public getView = () : Models.Camera.View360 => this.view;
+	public getView = () : Models.Camera.View => this.view;
 
 	/**
 	 * Gets the current image view rectangle [centerX, centerY, width, height] relative to the image (0-1).
@@ -224,10 +224,10 @@ export class Camera {
 
 	/**
 	 * Sets the camera view instantly to the specified viewport.
-	 * @param view The target viewport as either a View [x0, y0, x1, y1] or View360 {centerX, centerY, width, height}.
+	 * @param view The target viewport as either a View [x0, y0, x1, y1] or View {centerX, centerY, width, height}.
 	 * @param opts Options for setting the view.
 	 */
-	public setView(view: Models.Camera.ViewRect | Models.Camera.View360, opts: {
+	public setView(view: Models.Camera.ViewRect | Models.Camera.View, opts: {
 		/** If true, allows setting a view outside the normal image boundaries. */
 		noLimit?: boolean;
 		/** If true (for 360), corrects the view based on the `trueNorth` setting. */
@@ -239,7 +239,7 @@ export class Camera {
 	} = {}): void {
 		if (!this.e) return; // Exit if Wasm not ready
 
-		let { centerX, centerY, width, height } = this.isView360(view) ? view : View.fromLegacy(view)!;
+		let { centerX, centerY, width, height } = this.isView(view) ? view : View.fromLegacy(view)!;
 
 		if (opts.area) {
 			const absCoords = this.cooToArea(centerX, centerY, opts.area);
@@ -364,7 +364,7 @@ export class Camera {
 	 * Sets a rectangular limit for camera navigation within the image.
 	 * @param l The viewport limit rectangle [x0, y0, x1, y1].
 	*/
-	public setLimit(l:Models.Camera.ViewRect|Models.Camera.View360) : void {
+	public setLimit(l:Models.Camera.ViewRect|Models.Camera.View) : void {
 		if (!this.e) return;
 		l = View.sanitize(l)!;
 		this.e._setLimit(this.image.ptr, l.centerX, l.centerY, l.width, l.height);
@@ -404,17 +404,17 @@ export class Camera {
 
 	/**
 	 * Animates the camera smoothly to a target viewport.
-	 * @param view The target viewport as either a View [x0, y0, x1, y1] or View360 {centerX, centerY, width, height}.
+	 * @param view The target viewport as either a View [x0, y0, x1, y1] or View {centerX, centerY, width, height}.
 	 * @param opts Optional animation settings.
 	 * @returns A Promise that resolves when the animation completes, or rejects if aborted.
 	 */
 	public flyToView = (
-		view: Models.Camera.ViewRect | Models.Camera.View360,
+		view: Models.Camera.ViewRect | Models.Camera.View,
 		opts: Models.Camera.AnimationOptions & {
 			/** Set the starting animation progress percentage (0-1). */
 			progress?: number;
 			/** Base the progress override on this starting view. */
-			prevView?: Models.Camera.View360;
+			prevView?: Models.Camera.View;
 			/** If true, performs a "jump" animation (zooms out then in). */
 			isJump?: boolean;
 			/** For Omni objects: the target image frame index to animate to. */
@@ -431,7 +431,7 @@ export class Camera {
 	): Promise<void> => new Promise((ok, abort) => {
 		if (!this.e) return abort(new Error("Wasm not ready")); // Reject if Wasm not ready
 
-		let { centerX, centerY, width, height } = this.isView360(view) ? view : View.fromLegacy(view)!;
+		let { centerX, centerY, width, height } = this.isView(view) ? view : View.fromLegacy(view)!;
 
 		if(opts.margin?.length == 2) {
 			centerX += opts.margin[0];

--- a/src/ts/camera.ts
+++ b/src/ts/camera.ts
@@ -3,7 +3,7 @@ import type { MicrioWasmExports } from '../types/wasm';
 import type { Models } from '../types/models';
 
 import { tick } from 'svelte';
-import { legacyViewToView360, mod } from './utils';
+import { View, mod } from './utils';
 import { Enums } from './enums';
 
 /**
@@ -239,7 +239,7 @@ export class Camera {
 	} = {}): void {
 		if (!this.e) return; // Exit if Wasm not ready
 
-		let { centerX, centerY, width, height } = this.isView360(view) ? view : legacyViewToView360(view)!;
+		let { centerX, centerY, width, height } = this.isView360(view) ? view : View.fromLegacy(view)!;
 
 		if (opts.area) {
 			const absCoords = this.cooToArea(centerX, centerY, opts.area);
@@ -434,7 +434,7 @@ export class Camera {
 	): Promise<void> => new Promise((ok, abort) => {
 		if (!this.e) return abort(new Error("Wasm not ready")); // Reject if Wasm not ready
 
-		let { centerX, centerY, width, height } = this.isView360(view) ? view : legacyViewToView360(view)!;
+		let { centerX, centerY, width, height } = this.isView360(view) ? view : View.fromLegacy(view)!;
 
 		if(opts.margin?.length == 2) {
 			centerX += opts.margin[0];

--- a/src/ts/camera.ts
+++ b/src/ts/camera.ts
@@ -435,6 +435,8 @@ export class Camera {
 			area?: Models.Camera.View;
 			/** If true, respects the image's maximum zoom limit during animation. */
 			limitZoom?: boolean;
+			/** If provided, adds a margin to the view. */
+			margin?: [number, number];
 		} = {}
 	): Promise<void> => new Promise((ok, abort) => {
 		if (!this.e) return abort(new Error("Wasm not ready")); // Reject if Wasm not ready
@@ -447,6 +449,12 @@ export class Camera {
 			centerY = (view[1] + view[3]) / 2;
 			width = view[2] - view[0];
 			height = view[3] - view[1];
+		}
+		if(opts.margin?.length == 2) {
+			centerX += opts.margin[0];
+			centerY += opts.margin[1];
+			width -= opts.margin[0] * 2;
+			height -= opts.margin[1] * 2;
 		}
 		if (opts.area) {
 			const absCoords = this.cooToArea(centerX, centerY, opts.area);

--- a/src/ts/element.ts
+++ b/src/ts/element.ts
@@ -5,7 +5,7 @@ import type { Camera } from './camera';
 /** @ts-ignore */
 import type Svelte from '../svelte/Main.svelte';
 
-import { once, deepCopy, fetchJson, jsonCache, fetchInfo, fetchAlbumInfo, idIsV5, view360ToViewRaw, legacyViewToView360 } from './utils';
+import { once, deepCopy, fetchJson, jsonCache, fetchInfo, fetchAlbumInfo, idIsV5, legacyViewToView360 } from './utils';
 import { ATTRIBUTE_OPTIONS as AO, BASEPATH, BASEPATH_V5, localStorageKeys } from './globals';
 import { writable, get } from 'svelte/store';
 import { Wasm } from './wasm';
@@ -473,7 +473,7 @@ export class HTMLMicrioElement extends HTMLElement {
 
 		// Apply forced start view if provided
 		if(opts.startView) {
-			c.state.view.set(view360ToViewRaw(i.settings.view = opts.startView));
+			c.state.view.set(i.settings.view = opts.startView);
 			if(c.ptr && c.camera.e) c.camera.setView(i.settings.view,{noRender:true}); // Set immediately if camera ready
 		}
 

--- a/src/ts/element.ts
+++ b/src/ts/element.ts
@@ -5,7 +5,7 @@ import type { Camera } from './camera';
 /** @ts-ignore */
 import type Svelte from '../svelte/Main.svelte';
 
-import { once, deepCopy, fetchJson, jsonCache, fetchInfo, fetchAlbumInfo, idIsV5, legacyViewToView360 } from './utils';
+import { once, deepCopy, fetchJson, jsonCache, fetchInfo, fetchAlbumInfo, idIsV5, View } from './utils';
 import { ATTRIBUTE_OPTIONS as AO, BASEPATH, BASEPATH_V5, localStorageKeys } from './globals';
 import { writable, get } from 'svelte/store';
 import { Wasm } from './wasm';
@@ -699,7 +699,7 @@ export class HTMLMicrioElement extends HTMLElement {
 		);
 		sets.pinchZoomOutLimit = true; // Enable zoom out limit for galleries
 		// Set initial view to the starting page's area
-		if(opts.gallery.length) sets.view = legacyViewToView360(opts.gallery[Math.max(0, opts.gallery.findIndex(i => i.id == gallery!.startId))].opts.area);
+		if(opts.gallery.length) sets.view = View.fromLegacy(opts.gallery[Math.max(0, opts.gallery.findIndex(i => i.id == gallery!.startId))].opts.area);
 	}
 
 	/** Holds loaded grid info data if applicable. */

--- a/src/ts/element.ts
+++ b/src/ts/element.ts
@@ -417,7 +417,7 @@ export class HTMLMicrioElement extends HTMLElement {
 		/** If true, opens the split-screen view passively (doesn't take focus). */
 		isPassive?: boolean,
 		/** An optional starting view to apply immediately. */
-		startView?: Models.Camera.View360,
+		startView?: Models.Camera.View,
 		/** For 360 transitions, provides the direction vector from the previous image. */
 		vector?: Models.Camera.Vector,
 	}={}) : MicrioImage {

--- a/src/ts/element.ts
+++ b/src/ts/element.ts
@@ -5,7 +5,7 @@ import type { Camera } from './camera';
 /** @ts-ignore */
 import type Svelte from '../svelte/Main.svelte';
 
-import { once, deepCopy, fetchJson, jsonCache, fetchInfo, fetchAlbumInfo, idIsV5 } from './utils';
+import { once, deepCopy, fetchJson, jsonCache, fetchInfo, fetchAlbumInfo, idIsV5, view360ToViewRaw, legacyViewToView360 } from './utils';
 import { ATTRIBUTE_OPTIONS as AO, BASEPATH, BASEPATH_V5, localStorageKeys } from './globals';
 import { writable, get } from 'svelte/store';
 import { Wasm } from './wasm';
@@ -416,8 +416,8 @@ export class HTMLMicrioElement extends HTMLElement {
 		splitTo?: MicrioImage,
 		/** If true, opens the split-screen view passively (doesn't take focus). */
 		isPassive?: boolean,
-		/** An optional starting view `[x0, y0, x1, y1]` to apply immediately. */
-		startView?: Models.Camera.View,
+		/** An optional starting view to apply immediately. */
+		startView?: Models.Camera.View360,
 		/** For 360 transitions, provides the direction vector from the previous image. */
 		vector?: Models.Camera.Vector,
 	}={}) : MicrioImage {
@@ -473,7 +473,7 @@ export class HTMLMicrioElement extends HTMLElement {
 
 		// Apply forced start view if provided
 		if(opts.startView) {
-			c.state.view.set(i.settings.view = opts.startView);
+			c.state.view.set(view360ToViewRaw(i.settings.view = opts.startView));
 			if(c.ptr && c.camera.e) c.camera.setView(i.settings.view,{noRender:true}); // Set immediately if camera ready
 		}
 
@@ -699,7 +699,7 @@ export class HTMLMicrioElement extends HTMLElement {
 		);
 		sets.pinchZoomOutLimit = true; // Enable zoom out limit for galleries
 		// Set initial view to the starting page's area
-		if(opts.gallery.length) sets.view = opts.gallery[Math.max(0, opts.gallery.findIndex(i => i.id == gallery!.startId))].opts.area;
+		if(opts.gallery.length) sets.view = legacyViewToView360(opts.gallery[Math.max(0, opts.gallery.findIndex(i => i.id == gallery!.startId))].opts.area);
 	}
 
 	/** Holds loaded grid info data if applicable. */

--- a/src/ts/events.ts
+++ b/src/ts/events.ts
@@ -637,10 +637,7 @@ export const UpdateEvents:(keyof Models.MicrioEventMap)[] = [
 		if(!(e instanceof WheelEvent)) return; // Ensure WheelEvent
 		// Check if zoom is allowed based on settings and modifier keys
 		if(this.controlZoom && !e.ctrlKey) return;
-		if(!force && e.target instanceof Element && e.target != this.el && !e.target.classList.contains('marker') && !e.target.hasAttribute('data-scroll-through')) {
-			console.log('cancel?', e.target);
-			return;
-		}
+		if(!force && e.target instanceof Element && e.target != this.el && !e.target.classList.contains('marker') && !e.target.hasAttribute('data-scroll-through')) return;
 
 		let delta = e.deltaY;
 

--- a/src/ts/globals.ts
+++ b/src/ts/globals.ts
@@ -60,8 +60,8 @@ const DEFAULT_SETTINGS : Models.ImageInfo.Settings = {
 	camspeed: 1, // Camera animation speed multiplier
 
 	// Camera settings
-	view: [0,0,1,1], // Initial view [x0, y0, x1, y1]
-	restrict: [0,0,1,1], // View restriction boundaries [x0, y0, x1, y1]
+	view: {centerX: .5, centerY: .5, width: 1, height: 1}, // Initial view full view
+	restrict: {centerX: .5, centerY: .5, width: 1, height: 1}, // View restriction boundaries full image
 	focus: [.5,.5], // Default focus point [x, y] for zoom/cover view
 	zoomLimit: 1, // Maximum zoom factor relative to cover scale (1 = no zoom beyond cover)
 	fullscreen: true, // Enable fullscreen button

--- a/src/ts/grid.ts
+++ b/src/ts/grid.ts
@@ -312,7 +312,7 @@ export class Grid {
 		// Add previous layout to history if not disabled
 		if(!opts.noHistory && this.current.length) this.depth.set(this.history.push({
 			layout: this.current.map(i => this.getString(i.$info as Models.ImageInfo.ImageInfo, {
-				view: viewRawToView360(i.state.$view), // Store current view
+				view: i.state.$view, // Store current view
 				size: this.cellSizes.get(i.id) as [number,number] // Store current size
 			})).join(';'),
 			horizontal: this.isHorizontal, // Store layout orientation

--- a/src/ts/grid.ts
+++ b/src/ts/grid.ts
@@ -316,7 +316,7 @@ export class Grid {
 				size: this.cellSizes.get(i.id) as [number,number] // Store current size
 			})).join(';'),
 			horizontal: this.isHorizontal, // Store layout orientation
-			view: this.image.camera.getView() // Store main grid view
+			view: this.image.camera.getViewLegacy() // Store main grid view
 		}));
 
 		this.isHorizontal = !!opts.horizontal; // Update layout orientation
@@ -800,7 +800,7 @@ export class Grid {
 				: [1, 0, 2, 1], {noDispatch: true, direct: true});
 			layout = [
 				this.getString(current.$info!, {
-					view: exitView ?? current.camera.getView(),
+					view: exitView ?? current.camera.getViewLegacy(),
 					area: transDir == 0 ? [0, 1, 1, 2]
 						: transDir == 180 ? [0, -1, 1, 0]
 						: transDir == 270 ? [1, 0, 2, 1]

--- a/src/ts/grid.ts
+++ b/src/ts/grid.ts
@@ -8,7 +8,7 @@ import type { HTMLMicrioElement } from './element';
 
 import { MicrioImage } from './image';
 import { get, writable, type Unsubscriber, type Writable } from 'svelte/store';
-import { deepCopy, legacyViewToView360, once, sleep, view360ToViewRaw, viewRawToView360 } from './utils';
+import { deepCopy, once, sleep, View } from './utils';
 import { tick } from 'svelte';
 import { Enums } from '../ts/enums';
 
@@ -40,7 +40,7 @@ export class Grid {
 		i.height,
 		i.isDeepZoom ? 'd' : '', // 'd' for DeepZoom
 		i.isPng ? 'p':i.isWebP ? 'w' : '', // 'p' for PNG, 'w' for WebP
-		view360ToViewRaw(opts.view)?.map(round).join('/'), // View: cX,cY,w,h
+		View.toRaw(opts.view)?.map(round).join('/'), // View: cX,cY,w,h
 		opts.area?.map(round).join('/'), // Area: x0/y0/x1/y1
 		i.settings?.focus?.map(round).join('-'), // Focus: x-y
 		opts.cultures // Comma-separated cultures
@@ -316,7 +316,7 @@ export class Grid {
 				size: this.cellSizes.get(i.id) as [number,number] // Store current size
 			})).join(';'),
 			horizontal: this.isHorizontal, // Store layout orientation
-			view: this.image.camera.getViewLegacy() // Store main grid view
+			view: this.image.camera.getView() // Store main grid view
 		}));
 
 		this.isHorizontal = !!opts.horizontal; // Update layout orientation
@@ -689,7 +689,7 @@ export class Grid {
 			duration,
 			noHistory: true,
 			horizontal: state.horizontal,
-			view: legacyViewToView360(state.view)
+			view: state.view
 		});
 	}
 
@@ -815,8 +815,8 @@ export class Grid {
 			target.camera.setArea([0,0,1,1]);
 			target.camera.setView([0,0,1,1]);
 			const between = [
-				this.getString(current.$info!, {view: viewRawToView360([.5,.5,1,1])}),
-				this.getString(target.$info!, {view: viewRawToView360([.5,.5,1,1])})
+				this.getString(current.$info!, {view: View.fromRaw([.5,.5,1,1])}),
+				this.getString(target.$info!, {view: View.fromRaw([.5,.5,1,1])})
 			];
 			if(transition == 'behind-left') between.reverse();
 			await this.set(between.join(';'), {

--- a/src/ts/grid.ts
+++ b/src/ts/grid.ts
@@ -30,7 +30,7 @@ export class Grid {
 	 * @returns The formatted grid string for this image.
 	 */
 	static getString = (i:Models.ImageInfo.ImageInfo, opts: {
-		view?:Models.Camera.View360;
+		view?:Models.Camera.View;
 		area?:Models.Camera.ViewRect;
 		size?:number[];
 		cultures?: string;
@@ -224,7 +224,7 @@ export class Grid {
 		/** Overrides the default animation duration for the main grid view transition. */
 		duration?:number;
 		/** If provided, animates the main grid view to this viewport rectangle. */
-		view?:Models.Camera.View360;
+		view?:Models.Camera.View;
 		/** If true, skips the main grid camera animation. */
 		noCamAni?: boolean;
 		/** If true, forces area animation even for images not currently visible. */

--- a/src/ts/image.ts
+++ b/src/ts/image.ts
@@ -82,7 +82,7 @@ export class MicrioImage {
 	public swiper: GallerySwiper|undefined;
 
 	/** Stores the camera view state when a marker is opened, used to return to the previous view. */
-	openedView: Models.Camera.View|undefined;
+	openedView: Models.Camera.View360|undefined;
 
 	/** Internal reference to the video element.
 	 * @internal
@@ -167,7 +167,7 @@ export class MicrioImage {
 	opacity: number = 1;
 
 	/** Svelte Writable store holding the calculated pixel viewport [left, top, width, height] of this image within the main canvas. */
-	public readonly viewport:Writable<Models.Camera.View> = writable<Models.Camera.View>();
+	public readonly viewport:Writable<Models.Camera.ViewRect> = writable<Models.Camera.ViewRect>();
 
 	/** Predefined local data (info, data) if available.
 	 * @internal
@@ -201,7 +201,7 @@ export class MicrioImage {
 		private attr:Partial<Models.ImageInfo.ImageInfo>,
 		public opts:{
 			/** Optional sub area [x0, y0, x1, y1] defining placement within a parent canvas (for embeds/galleries). */
-			area?: Models.Camera.View;
+			area?: Models.Camera.ViewRect;
 			/** For split screen, the primary image this one is secondary to. */
 			secondaryTo?: MicrioImage;
 			/** If true, passively follows the view changes of the primary split-screen image. */
@@ -734,7 +734,7 @@ export class MicrioImage {
 	 * @param opts Embedding options (opacity, fit, etc.).
 	 * @returns The newly created embedded {@link MicrioImage} instance.
 	 */
-	addEmbed(info:Partial<Models.ImageInfo.ImageInfo>, area:Models.Camera.View, opts:Models.Embeds.EmbedOptions = {}) : MicrioImage {
+	addEmbed(info:Partial<Models.ImageInfo.ImageInfo>, area:Models.Camera.ViewRect, opts:Models.Embeds.EmbedOptions = {}) : MicrioImage {
 		const a = area.slice(0); // Clone area array
 		// Create new MicrioImage instance for the embed
 		const img = new MicrioImage(this.wasm, info, {area:a, isEmbed: true, useParentCamera: opts.asImage});

--- a/src/ts/image.ts
+++ b/src/ts/image.ts
@@ -412,8 +412,9 @@ export class MicrioImage {
 
 		// Set trueNorth for 360 images based on space data rotation
 		if(i.settings?._360) {
-			const rotY = micrio.spaceData?.images.find(img => img.id == this.id)?.rotationY??0;
-			i.settings._360.trueNorth = .5 + rotY / Math.PI / 2;
+			let rotY = micrio.spaceData?.images.find(img => img.id == this.id)?.rotationY??0;
+			while(rotY < 0) rotY += Math.PI * 2;
+			i.settings._360.trueNorth = (.5 + rotY / Math.PI / 2)%1;
 		}
 
 		// Set derived flags and properties

--- a/src/ts/image.ts
+++ b/src/ts/image.ts
@@ -82,7 +82,7 @@ export class MicrioImage {
 	public swiper: GallerySwiper|undefined;
 
 	/** Stores the camera view state when a marker is opened, used to return to the previous view. */
-	openedView: Models.Camera.View360|undefined;
+	openedView: Models.Camera.View|undefined;
 
 	/** Internal reference to the video element.
 	 * @internal

--- a/src/ts/state.ts
+++ b/src/ts/state.ts
@@ -255,11 +255,11 @@ export namespace State {
 	*/
 	export class Image {
 		/** Writable Svelte store holding the current viewport [centerX, centerY, width, height] of this image. */
-		public readonly view: Writable<Models.Camera.View360|undefined> = writable(undefined);
+		public readonly view: Writable<Models.Camera.View|undefined> = writable(undefined);
 		/** Internal reference to the current view. @internal */
-		private _view:Models.Camera.View360|undefined;
+		private _view:Models.Camera.View|undefined;
 		/** Getter for the current value of the {@link view} store. */
-		public get $view() : Models.Camera.View360|undefined {return this._view}
+		public get $view() : Models.Camera.View|undefined {return this._view}
 
 		/**
 		 * Writable Svelte store holding the currently active marker within *this specific image*.

--- a/src/ts/state.ts
+++ b/src/ts/state.ts
@@ -4,7 +4,7 @@ import type { HTMLMicrioElement } from './element';
 import type { MicrioImage } from './image';
 
 import { writable } from 'svelte/store';
-import { once, view360ToViewRaw, viewRawToView360 } from './utils';
+import { once, View } from './utils';
 
 /**
  * # Micrio State management
@@ -225,7 +225,7 @@ export namespace State {
 				// If no tour, fly to the saved view of the main image (if no marker was opened by state.set)
 				const mainImgState = s.c.find(i => i[0] == s.id);
 				if(mainImgState && !mainImgState[5] && this.micrio.$current) { // Check if marker ID (index 5) is absent
-					this.micrio.$current.camera.flyToView(viewRawToView360(mainImgState.slice(1,5) as Models.Camera.ViewRect)!, {speed:2}).catch(() => {});
+					this.micrio.$current.camera.flyToView(View.fromRaw(mainImgState.slice(1,5) as Models.Camera.ViewRect)!, {speed:2}).catch(() => {});
 				}
 			}
 		}
@@ -337,7 +337,7 @@ export namespace State {
 			// Construct the state array
 			return [
 				this.image.id,
-				...(view360ToViewRaw(this._view) ?? [0.5,0.5,1,1]), // Use current view or default
+				...(View.toRaw(this._view) ?? [0.5,0.5,1,1]), // Use current view or default
 				...(m ? [m.id, ...(media ? [media[0], media[1].currentTime, media[1].paused ? 'p' : undefined] : [])] : [undefined]) // Add marker ID and media state if present
 			].filter(v => v !== undefined) as ImageState; // Filter out undefined values
 		}
@@ -351,7 +351,7 @@ export namespace State {
 			if(!o?.length) return; // Exit if no state provided
 			// Set the view store (this will trigger updates)
 			// TODO: Should this flyToView instead of setting directly? Setting directly might cause jumps.
-			this.view.set(viewRawToView360(o as Models.Camera.ViewRect));
+			this.view.set(View.fromRaw(o as Models.Camera.ViewRect));
 			// Set the marker store if a marker ID is present in the state
 			if(o[5]) {
 				// Only set if different from current marker to avoid loops

--- a/src/ts/swiper.ts
+++ b/src/ts/swiper.ts
@@ -68,7 +68,7 @@ export class GallerySwiper {
 		this.image.state.view.subscribe(v =>
 			// Determine if swiping should be enabled based on zoom level and coverLimit option
 			this.isFullWidth = opts.coverLimit ? this.image.camera.isZoomedOut()
-				: v ? Math.round((v[2]-v[0])*1000)/1000 >= 1 : true // Check if view width is >= 1
+				: v ? Math.round(v.width*1000)/1000 >= 1 : true // Check if view width is >= 1
 		);
 
 		// Configure Wasm module for swipe interaction

--- a/src/ts/utils.ts
+++ b/src/ts/utils.ts
@@ -569,7 +569,7 @@ export const getIdVal=(a:string):number=>{let c=a.charCodeAt(0),u=c<91;return (c
 export const idIsV5 = (id:string):boolean => id.length == 6 || id.length == 7;
 
 /** Clamps a view rectangle the image bounds [0, 0, 1, 1]. */
-export const limitView = (v: Models.Camera.View360) : Models.Camera.View360 => {
+export const limitView = (v: Models.Camera.View) : Models.Camera.View => {
 	// Clamp width and height to maximum of 1
 	const width = Math.min(1, v.width);
 	const height = Math.min(1, v.height);
@@ -647,7 +647,7 @@ export const hasNativeHLS = (video?:HTMLMediaElement) : boolean => {
 
 export const View = {
 	/** Casts a raw view array ([centerX, centerY, width, height]) to a 360 view object. */
-	fromRaw: (v?:Models.Camera.ViewRect) : Models.Camera.View360|undefined => v ? ({
+	fromRaw: (v?:Models.Camera.ViewRect) : Models.Camera.View|undefined => v ? ({
 		centerX: v[0],
 		centerY: v[1],
 		width: v[2],
@@ -655,7 +655,7 @@ export const View = {
 	}) : undefined,
 	
 	/** Casts a 360 view object to a raw view array ([centerX, centerY, width, height]). */
-	toRaw: (v?:Models.Camera.View360) : Models.Camera.ViewRect|undefined => v ? [
+	toRaw: (v?:Models.Camera.View) : Models.Camera.ViewRect|undefined => v ? [
 		v.centerX,
 		v.centerY,
 		v.width,
@@ -663,7 +663,7 @@ export const View = {
 	] : undefined,
 	
 	/** Casts a legacy view array ([x0, y0, x1, y1]) to a 360 view object. */
-	fromLegacy: (v?:Models.Camera.ViewRect|Models.Camera.View360) : Models.Camera.View360|undefined => v && !('centerX' in v) ? ({
+	fromLegacy: (v?:Models.Camera.ViewRect|Models.Camera.View) : Models.Camera.View|undefined => v && !('centerX' in v) ? ({
 		centerX: (v[0] + v[2]) / 2,
 		centerY: (v[1] + v[3]) / 2,
 		width: v[2] - v[0],
@@ -671,14 +671,14 @@ export const View = {
 	}) : v,
 
 	/** Casts a 360 view object to a legacy view array ([x0, y0, x1, y1]). */
-	toLegacy: (v?:Models.Camera.View360) : Models.Camera.ViewRect|undefined => v && 'centerX' in v ? [
+	toLegacy: (v?:Models.Camera.View) : Models.Camera.ViewRect|undefined => v && 'centerX' in v ? [
 		v.centerX - v.width/2,
 		v.centerY - v.height/2,
 		v.centerX + v.width/2,
 		v.centerY + v.height/2
 	] : v,
 	
-	/** Sanitizes a viewport, converting from legacy array [x0,y0,x1,y1] to View360 if necessary. */
-	sanitize: (v?: any) : Models.Camera.View360|undefined => Array.isArray(v) ? View.fromLegacy(v) : v
+	/** Sanitizes a viewport, converting from legacy array [x0,y0,x1,y1] to View if necessary. */
+	sanitize: (v?: any) : Models.Camera.View|undefined => Array.isArray(v) ? View.fromLegacy(v) : v
 
 }

--- a/src/ts/utils.ts
+++ b/src/ts/utils.ts
@@ -619,14 +619,13 @@ export function getSpaceVector(micrio:HTMLMicrioElement, targetId: string) : {
 	const vN:Models.Spaces.DirectionVector = [v[0]*len, v[1]*len, v[2]*len];
 
 	// Calculate direction angle (yaw) and horizontal distance factor
-	const tNDiff = .5 - (image.$settings?._360?.trueNorth??.5); // True north offset
 	const directionX = mod((Math.atan2(-vN[0], vN[2])) / Math.PI/2); // Calculate yaw (0-1)
 	const distanceX = Math.max(0, Math.min(.4, Math.sqrt(vN[0]*vN[0] + vN[2]*vN[2]))); // Horizontal distance factor (clamped)
 
 	return {
 		v, vN, directionX,
 		vector: { // Vector object for micrio.open
-			direction: directionX%1-tNDiff, // Apply true north correction
+			direction: directionX%1, // Apply true north correction
 			distanceX,
 			distanceY: -v[1] // Vertical distance (inverted?)
 		}

--- a/src/ts/utils.ts
+++ b/src/ts/utils.ts
@@ -514,7 +514,7 @@ export async function loadSerialTour(image:MicrioImage, tour:Models.ImageData.Ma
 		// Get language-specific content and video tour data
 		const content = m?.i18n?.[lang] ?? (<unknown>m as Models.ImageData.MarkerCultureData);
 		if(content?.title) chapter = i; // Update chapter index if step has a title
-		const vTourData = !m?.videoTour ? undefined : 'timeline' in m.videoTour ? <unknown>m as Models.ImageData.VideoTourCultureData
+		const vTourData = !m?.videoTour ? undefined : 'timeline' in m.videoTour ? <unknown>m.videoTour as Models.ImageData.VideoTourCultureData
 			: m.videoTour.i18n?.[lang] ?? undefined;
 
 		// Sanitize assets within the step's content
@@ -528,8 +528,9 @@ export async function loadSerialTour(image:MicrioImage, tour:Models.ImageData.Ma
 			return undefined; // Skip this step
 		}
 
-		
 		sanitizeAsset(content?.audio);
+		// @ts-ignore
+		if(m.videoTour && content?.audio) m.videoTour['audio'] = content.audio;
 
 		// Create step info object
 		return {

--- a/src/ts/utils.ts
+++ b/src/ts/utils.ts
@@ -568,12 +568,21 @@ export const getIdVal=(a:string):number=>{let c=a.charCodeAt(0),u=c<91;return (c
 export const idIsV5 = (id:string):boolean => id.length == 6 || id.length == 7;
 
 /** Clamps a view rectangle the image bounds [0, 0, 1, 1]. */
-export const limitView = (v: Models.Camera.View360) : Models.Camera.View360 => ({
-	centerX: Math.max(0, v.centerX),
-	centerY: Math.max(0, v.centerY),
-	width: Math.min(1, v.centerX + v.width/2),
-	height: Math.min(1, v.centerY + v.height/2)
-});
+export const limitView = (v: Models.Camera.View360) : Models.Camera.View360 => {
+	// Clamp width and height to maximum of 1
+	const width = Math.min(1, v.width);
+	const height = Math.min(1, v.height);
+	
+	// Calculate half dimensions for boundary checking
+	const halfW = width / 2;
+	const halfH = height / 2;
+	
+	// Clamp center coordinates to keep rectangle within [0,0,1,1] bounds
+	const centerX = Math.max(halfW, Math.min(1 - halfW, v.centerX));
+	const centerY = Math.max(halfH, Math.min(1 - halfH, v.centerY));
+	
+	return { centerX, centerY, width, height };
+};
 
 /**
  * Calculates the 3D vector and navigation parameters between two images in a 360 space.

--- a/src/ts/videotour.ts
+++ b/src/ts/videotour.ts
@@ -21,10 +21,8 @@ type VideoTourSegment = {
 	pauseDuration: number;
 	/** Start time of this segment's animation (ms). */
 	start: number;
-	/** Target camera view rectangle [x0, y0, x1, y1] for this segment. */
-	view: Models.Camera.View;
-	/** Target camera view360 for this segment. */
-	view360?: Models.Camera.View360;
+	/** Target camera view for this segment. */
+	view: Models.Camera.View360;
 }
 
 
@@ -71,7 +69,7 @@ export class VideoTourInstance {
 	private micrio: HTMLMicrioElement;
 
 	/** The camera view when the tour started, used for resetting. @internal */
-	private initialView: Models.Camera.View|undefined;
+	private initialView: Models.Camera.View360|undefined;
 
 	/**
 	 * Creates a VideoTourInstance.
@@ -83,7 +81,7 @@ export class VideoTourInstance {
 		private data: Models.ImageData.VideoTour
 	) {
 		this.micrio = image.wasm.micrio;
-		this.initialView = image.camera.getViewLegacy(); // Store initial view
+		this.initialView = image.camera.getView(); // Store initial view
 
 		// Get language-specific content or fallback
 		const content = 'timeline' in data ? <unknown>data as Models.ImageData.VideoTourCultureData
@@ -257,9 +255,9 @@ export class VideoTourInstance {
 	}
 
 	/** Gets the target view for a specific step index. @internal */
-	private getView(i:number) : Models.Camera.View|undefined {
+	private getView(i:number) : Models.Camera.View360|undefined {
 		const step = this.timeline[i];
-		if(step == undefined) return this.initialView ?? this.image.camera.getViewLegacy(); // Fallback to initial or current view
+		if(step == undefined) return this.initialView ?? this.image.camera.getView(); // Fallback to initial or current view
 		else return step.view;
 	}
 

--- a/src/ts/videotour.ts
+++ b/src/ts/videotour.ts
@@ -83,7 +83,7 @@ export class VideoTourInstance {
 		private data: Models.ImageData.VideoTour
 	) {
 		this.micrio = image.wasm.micrio;
-		this.initialView = image.camera.getView(); // Store initial view
+		this.initialView = image.camera.getViewLegacy(); // Store initial view
 
 		// Get language-specific content or fallback
 		const content = 'timeline' in data ? <unknown>data as Models.ImageData.VideoTourCultureData
@@ -259,7 +259,7 @@ export class VideoTourInstance {
 	/** Gets the target view for a specific step index. @internal */
 	private getView(i:number) : Models.Camera.View|undefined {
 		const step = this.timeline[i];
-		if(step == undefined) return this.initialView ?? this.image.camera.getView(); // Fallback to initial or current view
+		if(step == undefined) return this.initialView ?? this.image.camera.getViewLegacy(); // Fallback to initial or current view
 		else return step.view;
 	}
 

--- a/src/ts/videotour.ts
+++ b/src/ts/videotour.ts
@@ -257,14 +257,7 @@ export class VideoTourInstance {
 	/** Gets the target view for a specific step index. @internal */
 	private getView(i:number) : Models.Camera.View360|undefined {
 		const step = this.timeline[i];
-		if(step == undefined) return this.initialView ?? this.image.camera.getView(); // Fallback to initial or current view
-		else return step.view;
-	}
-
-	private getView360(i:number) : Models.Camera.View360|undefined {
-		const step = this.timeline[i];
-		// Get the view360 from current timeline step
-		return step?.view360;
+		return step?.view;
 	}
 
 	/**
@@ -278,52 +271,31 @@ export class VideoTourInstance {
 
 		if(step == undefined) return; // Exit if step data not found
 
-		// Prefer view360 for 360 images, fall back to standard view
-		const nextView360 = this.getView360(this.currentIndex);
-		const nextView = step.view; // Target view for this step
-		const prevView360 = this.getView360(this.currentIndex-1);
-		const prevView = this.getView(this.currentIndex-1); // View from the previous step
-		const area = this.image.opts?.area; // Get current image area (for embeds/split)
+		const nextView = step.view;
+		const prevView = this.getView(this.currentIndex-1);
+		const area = this.image.opts?.area;
 
-		const useView360 = nextView360 && this.image.is360;
+		const useView360 = this.image.is360;
 
-		// If resuming from a paused state within an animation, calculate interpolated view and jump there
-		if(this.wasPaused && (prevView360 || prevView)) {
-			const b:number = this.micrio.wasm.e.ease(perc); // Get eased progress value
-			
-			if(useView360 && prevView360) {
-				// Interpolate between previous and next view360
-				const interpolatedView360 = {
-					centerX: prevView360.centerX * (1-b) + nextView360.centerX * b,
-					centerY: prevView360.centerY * (1-b) + nextView360.centerY * b,
-					width: prevView360.width * (1-b) + nextView360.width * b,
-					height: prevView360.height * (1-b) + nextView360.height * b,
-				};
-				this.image.camera.setView(interpolatedView360, {noLimit: true, area});
-			} else if(prevView && nextView) {
-				// Fallback to standard view interpolation
-				this.image.camera.setView([
-					prevView[0] * (1-b) + nextView[0] * b,
-					prevView[1] * (1-b) + nextView[1] * b,
-					prevView[2] * (1-b) + nextView[2] * b,
-					prevView[3] * (1-b) + nextView[3] * b,
-				], {noLimit: true, area});
-			}
-			this.nextStep(); // Immediately schedule next step (handles pause duration)
-		}
-		// Otherwise, start the animation
-		else {
-			const flyPromise = this.image.camera.flyToView(nextView360 || nextView, {
-					duration: step.duration, // Animation duration
-					progress: perc, // Starting progress
-					prevView: prevView, // Previous view for interpolation start
-					area // Apply area context if needed
-				});
-			
-			flyPromise
-				// When animation finishes, schedule the next step (handles pause duration)
-				.then(() => { if(this.currentIndex != undefined && step == this.timeline[this.currentIndex]) this.nextStep() })
-				.catch(() => {}); // Ignore animation abortion errors
+		if(this.wasPaused && prevView) {
+			const b:number = this.micrio.wasm.e.ease(perc);
+
+			const interpolatedView = {
+				centerX: prevView.centerX * (1-b) + nextView.centerX * b,
+				centerY: prevView.centerY * (1-b) + nextView.centerY * b,
+				width: prevView.width * (1-b) + nextView.width * b,
+				height: prevView.height * (1-b) + nextView.height * b,
+			};
+			this.image.camera.setView(interpolatedView, {noLimit: true, area});
+			this.nextStep();
+		} else {
+			const flyPromise = this.image.camera.flyToView(nextView, {
+				duration: step.duration,
+				progress: perc,
+				prevView: prevView,
+				area
+			});
+			flyPromise.then(() => { if(this.currentIndex != undefined && step == this.timeline[this.currentIndex]) this.nextStep() }).catch(() => {});
 		}
 	}
 

--- a/src/ts/videotour.ts
+++ b/src/ts/videotour.ts
@@ -22,7 +22,7 @@ type VideoTourSegment = {
 	/** Start time of this segment's animation (ms). */
 	start: number;
 	/** Target camera view for this segment. */
-	view: Models.Camera.View360;
+	view: Models.Camera.View;
 }
 
 
@@ -69,7 +69,7 @@ export class VideoTourInstance {
 	private micrio: HTMLMicrioElement;
 
 	/** The camera view when the tour started, used for resetting. @internal */
-	private initialView: Models.Camera.View360|undefined;
+	private initialView: Models.Camera.View|undefined;
 
 	/**
 	 * Creates a VideoTourInstance.
@@ -255,7 +255,7 @@ export class VideoTourInstance {
 	}
 
 	/** Gets the target view for a specific step index. @internal */
-	private getView(i:number) : Models.Camera.View360|undefined {
+	private getView(i:number) : Models.Camera.View|undefined {
 		const step = this.timeline[i];
 		return step?.view;
 	}
@@ -275,7 +275,7 @@ export class VideoTourInstance {
 		const prevView = this.getView(this.currentIndex-1);
 		const area = this.image.opts?.area;
 
-		const useView360 = this.image.is360;
+		const useView = this.image.is360;
 
 		if(this.wasPaused && prevView) {
 			const b:number = this.micrio.wasm.e.ease(perc);

--- a/src/ts/wasm.ts
+++ b/src/ts/wasm.ts
@@ -20,7 +20,7 @@ import { WASM } from './globals'; // Contains WASM binary data (likely base64)
 
 /** Promise for loading the Wasm binary (either from external source or embedded data). @internal */
 const wasmPromise : Promise<ArrayBuffer|Uint8Array> | null = WASM.ugz ? WASM.ugz(WASM.b64,!0) // Use decompression function if available
-	: fetch('http://localhost:2000/build/untouched.wasm').then(response => response.arrayBuffer()); // Fallback to fetching dev build
+	: fetch('http://localhost:2000/build/optimized.wasm').then(response => response.arrayBuffer()); // Fallback to fetching dev build
 
 /** Number of memory pages to allocate for Wasm (1 page = 64KB). @internal */
 const numPages : number = 100; // ~6.4MB

--- a/src/ts/wasm.ts
+++ b/src/ts/wasm.ts
@@ -439,12 +439,12 @@ export class Wasm {
 		// If canvas already exists in Wasm, just set it as active
 		else if(this.c != canvas.ptr) {
 			// Preserve orientation when switching between 360 images
-			const yaw = canvas.is360 && this.c >= 0 ? this.e._getYaw(this.c) : 0;
+			const yaw = canvas.is360 && this.c >= 0 ? this.e._getYaw(this.c, true) : 0;
 			const pitch = canvas.is360 && this.c >= 0 ? this.e._getPitch(this.c) : 0
 			this.c = canvas.ptr; // Update active canvas pointer
 			// Apply previous orientation if applicable (and not coming from waypoint)
 			if(canvas.is360 && !this.preventDirectionSet && yaw && pitch)
-				this.e._setDirection(this.c, yaw, pitch, true);
+				this.e._setDirection(this.c, yaw + (.5-(canvas.$settings?._360?.trueNorth||0))*Math.PI*2, pitch, true);
 			// Fade in if it was previously faded out
 			if(this.e._getTargetOpacity(canvas.ptr) == 0) this.e._fadeIn(canvas.ptr);
 			// Set initial Omni layer if applicable

--- a/src/ts/wasm.ts
+++ b/src/ts/wasm.ts
@@ -14,7 +14,7 @@ import type { MicrioWasmExports } from '../types/wasm';
 import { MicrioImage } from './image';
 import { get } from 'svelte/store';
 import { archive } from './archive';
-import { Browser, once, view360ToViewRaw } from './utils';
+import { Browser, once } from './utils';
 import { loadTexture, runningThreads, numThreads, abortDownload } from './textures';
 import { WASM } from './globals'; // Contains WASM binary data (likely base64)
 
@@ -381,9 +381,9 @@ export class Wasm {
 		this._pMatrices[mPtr] = new Float32Array(this.b, mPtr + 32, 16);
 
 		// Set initial view (from state, settings, or focus point)
-		const v = get(c.state.view) || view360ToViewRaw(settings.view);
-		if(v && v.toString() != '0.5,0.5,1,1') { // If specific view is set
-			this.e._setView(c.ptr, v[0], v[1], v[2], v[3], false, false, false);
+		const v = get(c.state.view) || settings.view;
+		if(v && !(v.centerX == .5 && v.centerY == .5 && v.width == 1 && v.height == 1)) { // If specific view is set
+			this.e._setView(c.ptr, v.centerX, v.centerY, v.width, v.height, false, false, false);
 		} else if((isSpaces || !i.is360) && focus && focus.toString() != '0.5,0.5') { // If focus point is set (and not default 360)
 			this.e._setCoo(c.ptr, focus[0], focus[1], 0, 0, performance.now()); // Set view centered on focus point
 			settings.focus = undefined; // Clear focus setting after applying

--- a/src/ts/wasm.ts
+++ b/src/ts/wasm.ts
@@ -350,6 +350,9 @@ export class Wasm {
 		// Set initial area if defined
 		if(c.opts.area) c.camera.setArea(c.opts.area, {direct: true, noDispatch:true, noRender:true});
 
+		// Set initial limit if defined
+		if(settings?.restrict) c.camera.setLimit(settings.restrict);
+
 		// Set custom durations if provided
 		if(settings?.crossfadeDuration)
 			this.e.setCrossfadeDuration(this.i, settings.crossfadeDuration);
@@ -836,11 +839,7 @@ export class Wasm {
 	 * @param noLimit If true, allows focus outside image bounds.
 	 */
 	setFocus(ptr:number, v:Models.Camera.ViewRect, noLimit:boolean=false) : void {
-		const centerX = (v[0] + v[2]) / 2;
-		const centerY = (v[1] + v[3]) / 2;
-		const width = v[2] - v[0];
-		const height = v[3] - v[1];
-		this.e._setFocus(ptr, centerX, centerY, width, height, noLimit);
+		this.e._setFocus(ptr, v[0], v[1], v[2], v[3], noLimit);
 	}
 
 }

--- a/src/types/models.ts
+++ b/src/types/models.ts
@@ -1264,7 +1264,7 @@ import type { IconDefinition } from '@fortawesome/free-solid-svg-icons';
 		export interface GridHistory {
 			layout: string;
 			horizontal: boolean;
-			view?: Camera.ViewRect;
+			view?: Camera.View360;
 		}
 	
 		export interface GridImageOptions {

--- a/src/types/models.ts
+++ b/src/types/models.ts
@@ -802,7 +802,7 @@ import type { IconDefinition } from '@fortawesome/free-solid-svg-icons';
 		 */
 		 export type Embed = Partial<ImageInfo.ImageInfo> & {
 			/** The area inside the main image to place the embed */
-			area: Camera.View360;
+			area: Camera.ViewRect;
 
 			/** Original asset url */
 			src?: string;

--- a/src/types/models.ts
+++ b/src/types/models.ts
@@ -1334,9 +1334,6 @@ import type { IconDefinition } from '@fortawesome/free-solid-svg-icons';
 
 	export namespace Camera {
 		/** A viewport rectangle */
-		export type View = number[]|Float64Array;
-
-		/** A viewport rectangle */
 		export type ViewRect = number[]|Float64Array;
 
 		/** A 360-degree area definition with center point and dimensions */

--- a/src/types/models.ts
+++ b/src/types/models.ts
@@ -195,12 +195,10 @@ import type { IconDefinition } from '@fortawesome/free-solid-svg-icons';
 
 		/** Micrio image settings, which is on load included as {@link ImageInfo}`.settings`. */
 		export type Settings = {
-			/** The starting viewport (`[x0,y0,x1,y1]`) */
-			view?: Camera.View;
-			/** The starting 360-degree area (alternative to view for spherical images) */
-			view360?: Camera.View360;
+			/** The starting viewport */
+			view?: Camera.View|Camera.View360;
 			/** Restrict navigation to this viewport (`[x0,y0,x1,y1]`) */
-			restrict?: Camera.View;
+			restrict?: Camera.View|Camera.View360;
 			/** Load a cover-initing image focussed on this coordinate (`[x, y]`) */
 			focus?: [number, number];
 
@@ -695,9 +693,7 @@ import type { IconDefinition } from '@fortawesome/free-solid-svg-icons';
 			visibleArc?: [number, number];
 
 			/** The viewport to zoom to when the marker is opened */
-			view?: Camera.View;
-			/** 360-degree area to zoom to when the marker is opened (alternative to view for spherical images) */
-			view360?: Camera.View360;
+			view?: Camera.View|Camera.View360;
 
 			/** If an image has multiple layers, switch to this layer */
 			imageLayer?: number;
@@ -806,9 +802,7 @@ import type { IconDefinition } from '@fortawesome/free-solid-svg-icons';
 		 */
 		 export type Embed = Partial<ImageInfo.ImageInfo> & {
 			/** The area inside the main image to place the embed */
-			area: Camera.View;
-			/** 360-degree area for the embed (alternative to area for spherical images) */
-			area360?: Camera.View360;
+			area: Camera.View|Camera.View360;
 
 			/** Original asset url */
 			src?: string;
@@ -901,9 +895,7 @@ import type { IconDefinition } from '@fortawesome/free-solid-svg-icons';
 			/** Viewport name */
 			title?: string;
 			/** View rectangle */
-			rect: Camera.View;
-			/** 360-degree area (alternative to rect for spherical images) */
-			view360?: Camera.View360;
+			rect: Camera.View|Camera.View360;
 		};
 
 		export interface VideoTourCultureData extends TourCultureData {
@@ -996,8 +988,7 @@ import type { IconDefinition } from '@fortawesome/free-solid-svg-icons';
 			micrioId: string,
 			duration: number,
 			imageHasOtherMarkers?: boolean,
-			startView?: Camera.View,
-			startView360?: Camera.View360,
+			startView?: Camera.View|Camera.View360,
 			chapter?: number,
 			/** For in grid multi-image tour, stay in the grid view */
 			gridView?: boolean,
@@ -1439,9 +1430,9 @@ import type { IconDefinition } from '@fortawesome/free-solid-svg-icons';
 
 		// Camera events
 		/** The camera has zoomed */
-		'zoom': { image: MicrioImage, view: Camera.View, view360?: Camera.View360 }; 
+		'zoom': { image: MicrioImage, view: Camera.View360|Camera.View }; 
 		/** The camera has moved */
-		'move': { image: MicrioImage, view: Camera.View, view360?: Camera.View360 }; 
+		'move': { image: MicrioImage, view: Camera.View360|Camera.View };
 		/** A frame has been drawn */
 		'draw': void; 
 		/** The <micr-io> element was resized */

--- a/src/types/models.ts
+++ b/src/types/models.ts
@@ -802,7 +802,7 @@ import type { IconDefinition } from '@fortawesome/free-solid-svg-icons';
 		 */
 		 export type Embed = Partial<ImageInfo.ImageInfo> & {
 			/** The area inside the main image to place the embed */
-			area: Camera.ViewRect;
+			area: Camera.View360;
 
 			/** Original asset url */
 			src?: string;

--- a/src/types/models.ts
+++ b/src/types/models.ts
@@ -196,9 +196,9 @@ import type { IconDefinition } from '@fortawesome/free-solid-svg-icons';
 		/** Micrio image settings, which is on load included as {@link ImageInfo}`.settings`. */
 		export type Settings = {
 			/** The starting viewport */
-			view?: Camera.View|Camera.View360;
+			view?: Camera.View360;
 			/** Restrict navigation to this viewport (`[x0,y0,x1,y1]`) */
-			restrict?: Camera.View|Camera.View360;
+			restrict?: Camera.View360;
 			/** Load a cover-initing image focussed on this coordinate (`[x, y]`) */
 			focus?: [number, number];
 
@@ -693,7 +693,7 @@ import type { IconDefinition } from '@fortawesome/free-solid-svg-icons';
 			visibleArc?: [number, number];
 
 			/** The viewport to zoom to when the marker is opened */
-			view?: Camera.View|Camera.View360;
+			view?: Camera.View360;
 
 			/** If an image has multiple layers, switch to this layer */
 			imageLayer?: number;
@@ -790,7 +790,7 @@ import type { IconDefinition } from '@fortawesome/free-solid-svg-icons';
 				micrioId: string,
 				markerId?: string,
 				follows?: boolean,
-				view?: Camera.View
+				view?: Camera.View360
 			}
 
 		};
@@ -802,7 +802,7 @@ import type { IconDefinition } from '@fortawesome/free-solid-svg-icons';
 		 */
 		 export type Embed = Partial<ImageInfo.ImageInfo> & {
 			/** The area inside the main image to place the embed */
-			area: Camera.View|Camera.View360;
+			area: Camera.View360;
 
 			/** Original asset url */
 			src?: string;
@@ -895,7 +895,7 @@ import type { IconDefinition } from '@fortawesome/free-solid-svg-icons';
 			/** Viewport name */
 			title?: string;
 			/** View rectangle */
-			rect: Camera.View|Camera.View360;
+			rect: Camera.View360;
 		};
 
 		export interface VideoTourCultureData extends TourCultureData {
@@ -988,7 +988,7 @@ import type { IconDefinition } from '@fortawesome/free-solid-svg-icons';
 			micrioId: string,
 			duration: number,
 			imageHasOtherMarkers?: boolean,
-			startView?: Camera.View|Camera.View360,
+			startView?: Camera.View360,
 			chapter?: number,
 			/** For in grid multi-image tour, stay in the grid view */
 			gridView?: boolean,
@@ -1220,7 +1220,7 @@ import type { IconDefinition } from '@fortawesome/free-solid-svg-icons';
 			thumbSrc?: string;
 			baseTileIdx: number;
 			ptr: number;
-			opts: { area: Camera.View; };
+			opts: { area: Camera.ViewRect; };
 		}
 	}
 
@@ -1257,25 +1257,25 @@ import type { IconDefinition } from '@fortawesome/free-solid-svg-icons';
 		/** Virtual ImageInfo extension to support grid logic */
 		export interface GridImage extends Partial<ImageInfo.ImageInfo> {
 			size: [number, number?];
-			area?: Camera.View;
-			view?: Camera.View;
+			area?: Camera.ViewRect;
+			view?: Camera.ViewRect;
 		}
 
 		export interface GridHistory {
 			layout: string;
 			horizontal: boolean;
-			view?: Camera.View;
+			view?: Camera.ViewRect;
 		}
 	
 		export interface GridImageOptions {
-			view?:Camera.View;
-			area?:Camera.View;
+			view?:Camera.View360;
+			area?:Camera.ViewRect;
 			size?:number[];
 		}
 	
 		export interface FocusOptions {
 			/** Optional target image view */
-			view?: Camera.View;
+			view?: Camera.View360;
 			/** Transition duration in ms */
 			duration?: number;
 			/** Transition animation, defaults to crossfade */
@@ -1283,7 +1283,7 @@ import type { IconDefinition } from '@fortawesome/free-solid-svg-icons';
 			/** Set the target viewport immediately */
 			noViewAni?: boolean;
 			/** Animate the previously focussed image to this view during exit transition */
-			exitView?: Camera.View;
+			exitView?: Camera.View360;
 			/** Limit the focussed image to cover view, defaults to false */
 			coverLimit?: boolean;
 			/** Open as cover view, but don't limit it */
@@ -1335,6 +1335,9 @@ import type { IconDefinition } from '@fortawesome/free-solid-svg-icons';
 	export namespace Camera {
 		/** A viewport rectangle */
 		export type View = number[]|Float64Array;
+
+		/** A viewport rectangle */
+		export type ViewRect = number[]|Float64Array;
 
 		/** A 360-degree area definition with center point and dimensions */
 		export interface View360 {
@@ -1430,9 +1433,9 @@ import type { IconDefinition } from '@fortawesome/free-solid-svg-icons';
 
 		// Camera events
 		/** The camera has zoomed */
-		'zoom': { image: MicrioImage, view: Camera.View360|Camera.View }; 
+		'zoom': { image: MicrioImage, view: Camera.View360 }; 
 		/** The camera has moved */
-		'move': { image: MicrioImage, view: Camera.View360|Camera.View };
+		'move': { image: MicrioImage, view: Camera.View360 };
 		/** A frame has been drawn */
 		'draw': void; 
 		/** The <micr-io> element was resized */

--- a/src/types/models.ts
+++ b/src/types/models.ts
@@ -196,9 +196,9 @@ import type { IconDefinition } from '@fortawesome/free-solid-svg-icons';
 		/** Micrio image settings, which is on load included as {@link ImageInfo}`.settings`. */
 		export type Settings = {
 			/** The starting viewport */
-			view?: Camera.View360;
+			view?: Camera.View;
 			/** Restrict navigation to this viewport (`[x0,y0,x1,y1]`) */
-			restrict?: Camera.View360;
+			restrict?: Camera.View;
 			/** Load a cover-initing image focussed on this coordinate (`[x, y]`) */
 			focus?: [number, number];
 
@@ -693,7 +693,7 @@ import type { IconDefinition } from '@fortawesome/free-solid-svg-icons';
 			visibleArc?: [number, number];
 
 			/** The viewport to zoom to when the marker is opened */
-			view?: Camera.View360;
+			view?: Camera.View;
 
 			/** If an image has multiple layers, switch to this layer */
 			imageLayer?: number;
@@ -790,7 +790,7 @@ import type { IconDefinition } from '@fortawesome/free-solid-svg-icons';
 				micrioId: string,
 				markerId?: string,
 				follows?: boolean,
-				view?: Camera.View360
+				view?: Camera.View
 			}
 
 		};
@@ -802,7 +802,7 @@ import type { IconDefinition } from '@fortawesome/free-solid-svg-icons';
 		 */
 		 export type Embed = Partial<ImageInfo.ImageInfo> & {
 			/** The area inside the main image to place the embed */
-			area: Camera.View360;
+			area: Camera.View;
 
 			/** Original asset url */
 			src?: string;
@@ -895,7 +895,7 @@ import type { IconDefinition } from '@fortawesome/free-solid-svg-icons';
 			/** Viewport name */
 			title?: string;
 			/** View rectangle */
-			rect: Camera.View360;
+			rect: Camera.View;
 		};
 
 		export interface VideoTourCultureData extends TourCultureData {
@@ -988,7 +988,7 @@ import type { IconDefinition } from '@fortawesome/free-solid-svg-icons';
 			micrioId: string,
 			duration: number,
 			imageHasOtherMarkers?: boolean,
-			startView?: Camera.View360,
+			startView?: Camera.View,
 			chapter?: number,
 			/** For in grid multi-image tour, stay in the grid view */
 			gridView?: boolean,
@@ -1264,18 +1264,18 @@ import type { IconDefinition } from '@fortawesome/free-solid-svg-icons';
 		export interface GridHistory {
 			layout: string;
 			horizontal: boolean;
-			view?: Camera.View360;
+			view?: Camera.View;
 		}
 	
 		export interface GridImageOptions {
-			view?:Camera.View360;
+			view?:Camera.View;
 			area?:Camera.ViewRect;
 			size?:number[];
 		}
 	
 		export interface FocusOptions {
 			/** Optional target image view */
-			view?: Camera.View360;
+			view?: Camera.View;
 			/** Transition duration in ms */
 			duration?: number;
 			/** Transition animation, defaults to crossfade */
@@ -1283,7 +1283,7 @@ import type { IconDefinition } from '@fortawesome/free-solid-svg-icons';
 			/** Set the target viewport immediately */
 			noViewAni?: boolean;
 			/** Animate the previously focussed image to this view during exit transition */
-			exitView?: Camera.View360;
+			exitView?: Camera.View;
 			/** Limit the focussed image to cover view, defaults to false */
 			coverLimit?: boolean;
 			/** Open as cover view, but don't limit it */
@@ -1337,7 +1337,7 @@ import type { IconDefinition } from '@fortawesome/free-solid-svg-icons';
 		export type ViewRect = number[]|Float64Array;
 
 		/** A 360-degree area definition with center point and dimensions */
-		export interface View360 {
+		export interface View {
 			/** Center X coordinate (0-1 relative to image) */
 			centerX: number;
 			/** Center Y coordinate (0-1 relative to image) */
@@ -1432,9 +1432,9 @@ import type { IconDefinition } from '@fortawesome/free-solid-svg-icons';
 
 		// Camera events
 		/** The camera has zoomed */
-		'zoom': { image: MicrioImage, view: Camera.View360 }; 
+		'zoom': { image: MicrioImage, view: Camera.View }; 
 		/** The camera has moved */
-		'move': { image: MicrioImage, view: Camera.View360 };
+		'move': { image: MicrioImage, view: Camera.View };
 		/** A frame has been drawn */
 		'draw': void; 
 		/** The <micr-io> element was resized */

--- a/src/types/models.ts
+++ b/src/types/models.ts
@@ -1346,6 +1346,8 @@ import type { IconDefinition } from '@fortawesome/free-solid-svg-icons';
 			width: number;
 			/** Height (0-1 relative to image) */
 			height: number;
+			/** Rotate an omni object to this frame index */
+			omniIndex?: number;
 		}
 
 		/** Coordinate tuple, [x, y, scale] */

--- a/src/types/wasm.ts
+++ b/src/types/wasm.ts
@@ -347,10 +347,10 @@ export interface MicrioWasmExports extends WebAssembly.Exports {
 	_getScale(ptr:number) : number;
 	/** Limit camera navigation boundaries
 	 * @param ptr The sub image memory pointer in shared Wasm memory
-	 * @param lCenterX The viewport X0 coordinate
-	 * @param lCenterY The viewport Y0 coordinate
-	 * @param lWidth The viewport X1 coordinate
-	 * @param lHeight The viewport Y1 coordinate
+	 * @param lCenterX The viewport center X coordinate
+	 * @param lCenterY The viewport center Y coordinate
+	 * @param lWidth The viewport width
+	 * @param lHeight The viewport height
 	*/
 	_setLimit(ptr:number, lCenterX: number, lCenterY: number, lWidth: number, lHeight: number) : void;
 	/** Limit camera navigation boundaries in 360&deg; images
@@ -480,13 +480,13 @@ export interface MicrioWasmExports extends WebAssembly.Exports {
 	/** Set an active image in a swipeable gallery, flying to its relative viewport
 	 * inside the containing canvas.
 	 * @param ptr The sub image memory pointer in shared Wasm memory
-	 * @param centerX The viewport X0 coordinate
-	 * @param centerY The viewport Y0 coordinate
-	 * @param width The viewport X1 coordinate
-	 * @param height The viewport Y1 coordinate
+	 * @param x0 The viewport X0 coordinate
+	 * @param y0 The viewport Y0 coordinate
+	 * @param x1 The viewport X1 coordinate
+	 * @param y1 The viewport Y1 coordinate
 	 * @param noLimit Don't update the zoom limits
 	*/
-	_setFocus(ptr:number, centerX:number, centerY:number, width:number, height:number, noLimit:boolean) : void;
+	_setFocus(ptr:number, x0:number, y0:number, x1:number, y1:number, noLimit:boolean) : void;
 	/** Fade a main MicrioImage to a target opacity, including all of its sub-images
 	 * @param ptr The sub image memory pointer in shared Wasm memory
 	 * @param o The target opacity (`0-1`)

--- a/src/types/wasm.ts
+++ b/src/types/wasm.ts
@@ -270,17 +270,6 @@ export interface MicrioWasmExports extends WebAssembly.Exports {
 	 * @param correctNorth Internally adjust relative 360&deg; rotation
 	*/
 	_setView(ptr:number, centerX: number, centerY: number, width: number, height: number, noLimit?: boolean, noLastView?: boolean, correctNorth?: boolean) : void;
-	/** Set the current camera viewport using 360-degree area format
-	 * @param ptr The sub image memory pointer in shared Wasm memory
-	 * @param centerX The center X coordinate (0-1)
-	 * @param centerY The center Y coordinate (0-1)
-	 * @param width The area width (0-1)
-	 * @param height The area height (0-1)
-	 * @param noLimit The viewport can be outside of the image's limits
-	 * @param noLastView Don't keep track of the previous viewport
-	 * @param correctNorth Internally adjust relative 360° rotation
-	 */
-	_setView360(ptr:number, centerX: number, centerY: number, width: number, height: number, noLimit?: boolean, noLastView?: boolean, correctNorth?: boolean) : void;
 	/** Set the current camera coordinates
 	 * @param ptr The sub image memory pointer in shared Wasm memory
 	 * @param x The X coordinate

--- a/src/types/wasm.ts
+++ b/src/types/wasm.ts
@@ -281,11 +281,6 @@ export interface MicrioWasmExports extends WebAssembly.Exports {
 	 * @param correctNorth Internally adjust relative 360° rotation
 	 */
 	_setView360(ptr:number, centerX: number, centerY: number, width: number, height: number, noLimit?: boolean, noLastView?: boolean, correctNorth?: boolean) : void;
-	/** Get the current camera view as a 360-degree area
-	 * @param ptr The sub image memory pointer in shared Wasm memory
-	 * @returns Pointer to a Float64Array containing [centerX, centerY, width, height]
-	 */
-	_getView360(ptr:number) : number;
 	/** Set the current camera coordinates
 	 * @param ptr The sub image memory pointer in shared Wasm memory
 	 * @param x The X coordinate

--- a/src/types/wasm.ts
+++ b/src/types/wasm.ts
@@ -207,22 +207,22 @@ export interface MicrioWasmExports extends WebAssembly.Exports {
 	_getOmniXY(ptr:number, x: number, y: number, z: number) : number;
 	/** Set the relative View area of a MicrioImage to render to, animates by default. Used in grids.
 	 * @param ptr The image memory pointer in shared Wasm memory
-	 * @param centerX The viewport X0 coordinate
-	 * @param centerY The viewport Y0 coordinate
-	 * @param width The viewport X1 coordinate
-	 * @param height The viewport Y1 coordinate
+	 * @param X0 The viewport X0 coordinate
+	 * @param Y0 The viewport Y0 coordinate
+	 * @param X1 The viewport X1 coordinate
+	 * @param Y1 The viewport Y1 coordinate
 	 * @param direct Don't animate
 	 * @param noDispatch Don't do a frame draw after setting
 	 */
-	_setArea(ptr:number, centerX:number, centerY:number, width:number, height:number, direct:boolean, noDispatch:boolean) : void;
+	_setArea(ptr:number, X0:number, Y0:number, X1:number, Y1:number, direct:boolean, noDispatch:boolean) : void;
 	/** Set the relative View area of an embedded image to render to.
 	 * @param ptr The sub image memory pointer in shared Wasm memory
-	 * @param centerX The viewport X0 coordinate
-	 * @param centerY The viewport Y0 coordinate
-	 * @param width The viewport X1 coordinate
-	 * @param height The viewport Y1 coordinate
+	 * @param X0 The viewport X0 coordinate
+	 * @param Y0 The viewport Y0 coordinate
+	 * @param X1 The viewport X1 coordinate
+	 * @param Y1 The viewport Y1 coordinate
 	 */
-	_setImageArea(imgPtr:number, centerX:number, centerY:number, width:number, height:number) : void;
+	_setImageArea(imgPtr:number, X0:number, Y0:number, X1:number, Y1:number) : void;
 	/** Set an embedded sub-image rotation in 3d space for 360&deg; images.
 	 * @param ptr The sub image memory pointer in shared Wasm memory
 	 * @param rotX The rotation over the X-axis

--- a/src/types/wasm.ts
+++ b/src/types/wasm.ts
@@ -157,7 +157,7 @@ export interface MicrioWasmExports extends WebAssembly.Exports {
 		freeMove: boolean, coverLimit: boolean, coverStart: boolean, maxScale: number, camSpeed: number,
 		trueNorth: number, isGallerySwitch: boolean, pagesHaveBackground: boolean,
 		isOmni: boolean, pinchZoomOutLimit: boolean, omniNumLayers: number, omniLayerStartIndex:number) : number;
-	/** Get the requested image's current view coordinates `[x0, y0, x1, y1]`
+	/** Get the requested image's current view coordinates [centerX, centerY, width, height]
 	 * @param ptr The image memory pointer in shared Wasm memory
 	 * @returns Memory pointer to the `Uint32Array` containing the coordinates
 	 */
@@ -207,22 +207,22 @@ export interface MicrioWasmExports extends WebAssembly.Exports {
 	_getOmniXY(ptr:number, x: number, y: number, z: number) : number;
 	/** Set the relative View area of a MicrioImage to render to, animates by default. Used in grids.
 	 * @param ptr The image memory pointer in shared Wasm memory
-	 * @param x0 The viewport X0 coordinate
-	 * @param y0 The viewport Y0 coordinate
-	 * @param x1 The viewport X1 coordinate
-	 * @param y1 The viewport Y1 coordinate
+	 * @param centerX The viewport X0 coordinate
+	 * @param centerY The viewport Y0 coordinate
+	 * @param width The viewport X1 coordinate
+	 * @param height The viewport Y1 coordinate
 	 * @param direct Don't animate
 	 * @param noDispatch Don't do a frame draw after setting
 	 */
-	_setArea(ptr:number, x0:number,y0:number,x1:number,y1:number,direct:boolean,noDispatch:boolean) : void;
+	_setArea(ptr:number, centerX:number, centerY:number, width:number, height:number, direct:boolean, noDispatch:boolean) : void;
 	/** Set the relative View area of an embedded image to render to.
 	 * @param ptr The sub image memory pointer in shared Wasm memory
-	 * @param x0 The viewport X0 coordinate
-	 * @param y0 The viewport Y0 coordinate
-	 * @param x1 The viewport X1 coordinate
-	 * @param y1 The viewport Y1 coordinate
+	 * @param centerX The viewport X0 coordinate
+	 * @param centerY The viewport Y0 coordinate
+	 * @param width The viewport X1 coordinate
+	 * @param height The viewport Y1 coordinate
 	 */
-	_setImageArea(imgPtr:number, x0:number,y0:number,x1:number,y1:number) : void;
+	_setImageArea(imgPtr:number, centerX:number, centerY:number, width:number, height:number) : void;
 	/** Set an embedded sub-image rotation in 3d space for 360&deg; images.
 	 * @param ptr The sub image memory pointer in shared Wasm memory
 	 * @param rotX The rotation over the X-axis
@@ -261,15 +261,15 @@ export interface MicrioWasmExports extends WebAssembly.Exports {
 	_setDirection(ptr:number, yaw: number, pitch?: number, resetPersp?: boolean) : void;
 	/** Set the current camera viewport
 	 * @param ptr The sub image memory pointer in shared Wasm memory
-	 * @param x0 The viewport X0 coordinate
-	 * @param y0 The viewport Y0 coordinate
-	 * @param x1 The viewport X1 coordinate
-	 * @param y1 The viewport Y1 coordinate
+	 * @param centerX The viewport X0 coordinate
+	 * @param centerY The viewport Y0 coordinate
+	 * @param width The viewport X1 coordinate
+	 * @param height The viewport Y1 coordinate
 	 * @param noLimit The viewport can be outside of the image's limits
 	 * @param noLastView Don't keep track of the previous viewport
 	 * @param correctNorth Internally adjust relative 360&deg; rotation
 	*/
-	_setView(ptr:number, x0: number, y0: number, x1: number, y1: number, noLimit?: boolean, noLastView?: boolean, correctNorth?: boolean) : void;
+	_setView(ptr:number, centerX: number, centerY: number, width: number, height: number, noLimit?: boolean, noLastView?: boolean, correctNorth?: boolean) : void;
 	/** Set the current camera viewport using 360-degree area format
 	 * @param ptr The sub image memory pointer in shared Wasm memory
 	 * @param centerX The center X coordinate (0-1)
@@ -363,12 +363,12 @@ export interface MicrioWasmExports extends WebAssembly.Exports {
 	_getScale(ptr:number) : number;
 	/** Limit camera navigation boundaries
 	 * @param ptr The sub image memory pointer in shared Wasm memory
-	 * @param x0 The viewport X0 coordinate
-	 * @param y0 The viewport Y0 coordinate
-	 * @param x1 The viewport X1 coordinate
-	 * @param y1 The viewport Y1 coordinate
+	 * @param lCenterX The viewport X0 coordinate
+	 * @param lCenterY The viewport Y0 coordinate
+	 * @param lWidth The viewport X1 coordinate
+	 * @param lHeight The viewport Y1 coordinate
 	*/
-	_setLimit(ptr:number, x0: number, y0: number, x1: number, y1: number) : void;
+	_setLimit(ptr:number, lCenterX: number, lCenterY: number, lWidth: number, lHeight: number) : void;
 	/** Limit camera navigation boundaries in 360&deg; images
 	 * @param ptr The sub image memory pointer in shared Wasm memory
 	 * @param x The horizontal view limits in radians
@@ -413,18 +413,18 @@ export interface MicrioWasmExports extends WebAssembly.Exports {
 	_panStop(ptr:number) : void;
 	/** Set an image's opening view
 	 * @param ptr The sub image memory pointer in shared Wasm memory
-	 * @param x0 The viewport X0 coordinate
-	 * @param y0 The viewport Y0 coordinate
-	 * @param x1 The viewport X1 coordinate
-	 * @param y1 The viewport Y1 coordinate
+	 * @param centerX The viewport X0 coordinate
+	 * @param centerY The viewport Y0 coordinate
+	 * @param width The viewport X1 coordinate
+	 * @param height The viewport Y1 coordinate
 	*/
-	_setStartView(ptr: number, x0:number, y0:number, x1:number, y1:number) : void;
+	_setStartView(ptr: number, centerX:number, centerY:number, width:number, height:number) : void;
 	/** Fly to a specific viewport
 	 * @param ptr The sub image memory pointer in shared Wasm memory
-	 * @param toX0 The viewport X0 coordinate
-	 * @param toY0 The viewport Y0 coordinate
-	 * @param toX1 The viewport X1 coordinate
-	 * @param toY1 The viewport Y1 coordinate
+	 * @param toCenterX The viewport X0 coordinate
+	 * @param toCenterY The viewport Y0 coordinate
+	 * @param toWidth The viewport X1 coordinate
+	 * @param toHeight The viewport Y1 coordinate
 	 * @param dur The animation duration in ms, use `-1` for `auto`
 	 * @param speed When duration `auto`, a speed modifier (default `1`)
 	 * @param perc Start the animation at a certain progress (`0-1`)
@@ -437,26 +437,7 @@ export interface MicrioWasmExports extends WebAssembly.Exports {
 	 * @param time The current timestamp (`performance.now()`)
 	 * @returns The resulting animation duration in ms
 	*/
-	_flyTo(ptr:number, toX0: number, toY0: number, toX1: number, toY1: number, dur: number, speed: number, perc: number, isJump: boolean, limit: boolean, limitZoom: boolean, toOmniIdx: number, noTrueNorth: boolean, fn:number, time: number) : number;
-	/** Fly to a specific 360-degree area with smart longitude wrapping
-	 * @param ptr The sub image memory pointer in shared Wasm memory
-	 * @param centerX The target center X coordinate (0-1)
-	 * @param centerY The target center Y coordinate (0-1)
-	 * @param width The target area width (0-1)
-	 * @param height The target area height (0-1)
-	 * @param dur The animation duration in ms, use `-1` for `auto`
-	 * @param speed When duration `auto`, a speed modifier (default `1`)
-	 * @param perc Start the animation at a certain progress (`0-1`)
-	 * @param isJump Make the camera zoom out and in during this animation
-	 * @param limit Limit the animation to the image's boundaries
-	 * @param limitZoom Don't allow the animation to zoom in further than the maximum zoom
-	 * @param toOmniIdx For rotatable omni objects, also animate to this frame
-	 * @param noTrueNorth Internally apply local relative 360° image rotation
-	 * @param fn Animation timing function: `0: ease`, `1: ease-in`, `2: ease-out`, `3: linear`
-	 * @param time The current timestamp (`performance.now()`)
-	 * @returns The resulting animation duration in ms
-	 */
-	_flyToView360(ptr:number, centerX: number, centerY: number, width: number, height: number, dur: number, speed: number, perc: number, isJump: boolean, limit: boolean, limitZoom: boolean, toOmniIdx: number, noTrueNorth: boolean, fn:number, time: number) : number;
+	_flyTo(ptr:number, toCenterX: number, toCenterY: number, toWidth: number, toHeight: number, dur: number, speed: number, perc: number, isJump: boolean, limit: boolean, limitZoom: boolean, toOmniIdx: number, noTrueNorth: boolean, fn:number, time: number) : number;
 	/** A zoom in/out animation
 	 * @param ptr The sub image memory pointer in shared Wasm memory
 	 * @param d The amount to zoom
@@ -515,13 +496,13 @@ export interface MicrioWasmExports extends WebAssembly.Exports {
 	/** Set an active image in a swipeable gallery, flying to its relative viewport
 	 * inside the containing canvas.
 	 * @param ptr The sub image memory pointer in shared Wasm memory
-	 * @param x0 The viewport X0 coordinate
-	 * @param y0 The viewport Y0 coordinate
-	 * @param x1 The viewport X1 coordinate
-	 * @param y1 The viewport Y1 coordinate
+	 * @param centerX The viewport X0 coordinate
+	 * @param centerY The viewport Y0 coordinate
+	 * @param width The viewport X1 coordinate
+	 * @param height The viewport Y1 coordinate
 	 * @param noLimit Don't update the zoom limits
 	*/
-	_setFocus(ptr:number, x0:number, y0:number, x1:number, y1:number, noLimit:boolean) : void;
+	_setFocus(ptr:number, centerX:number, centerY:number, width:number, height:number, noLimit:boolean) : void;
 	/** Fade a main MicrioImage to a target opacity, including all of its sub-images
 	 * @param ptr The sub image memory pointer in shared Wasm memory
 	 * @param o The target opacity (`0-1`)

--- a/src/types/wasm.ts
+++ b/src/types/wasm.ts
@@ -200,9 +200,10 @@ export interface MicrioWasmExports extends WebAssembly.Exports {
 	 * @param t Optional Y translation in 3d space
 	 * @param sX Optional X scaling
 	 * @param sY Optional Y scaling
+	 * @param noCorrectNorth Don't correct for true north
 	 * @returns Memory pointer to the `Uint32Array` containing the Matrix4 array
 	 */
-	_getMatrix(ptr:number, x?:number, y?:number, s?:number, r?:number, rX?:number, rY?:number, rZ?:number, t?:number, sX?:number, sY?:number) : number;
+	_getMatrix(ptr:number, x?:number, y?:number, s?:number, r?:number, rX?:number, rY?:number, rZ?:number, t?:number, sX?:number, sY?:number, noCorrectNorth?: boolean) : number;
 	/** Get the screen coordinates based on omni object xyz coordinates */
 	_getOmniXY(ptr:number, x: number, y: number, z: number) : number;
 	/** Set the relative View area of a MicrioImage to render to, animates by default. Used in grids.
@@ -291,7 +292,7 @@ export interface MicrioWasmExports extends WebAssembly.Exports {
 	 * @param ptr The sub image memory pointer in shared Wasm memory
 	 * @returns The current yaw in radians
 	*/
-	_getYaw(ptr:number) : number;
+	_getYaw(ptr:number, noCorrectNorth?: boolean) : number;
 	/** Get the current camera pitch (X-axis rotation) for 360&deg; images
 	 * @param ptr The sub image memory pointer in shared Wasm memory
 	 * @returns The current pitch in radians

--- a/src/wasm/camera.ani.ts
+++ b/src/wasm/camera.ani.ts
@@ -251,7 +251,12 @@ export default class Ani {
 		const dCenterY = abs(fromCenterY - toCenterY);
 		const dWidth = abs(fromWidth - toWidth);
 		const dHeight = abs(fromHeight - toHeight);
-		const dst = (dCenterX + dCenterY + dWidth / 2 + dHeight / 2) / 3; // Adjusted normalization
+		
+		// Detect zoom-in operations (target is smaller than current view)
+		const isZoomIn = toWidth < fromWidth && toHeight < fromHeight;
+		// Reduce weight of zoom-in operations for faster transitions (zoom feels faster than panning to users)
+		const zoomWeight = isZoomIn ? 0.125 : 0.25; // 25% weight for zoom-in, 50% for zoom-out/mixed
+		const dst = (dCenterX + dCenterY + dWidth * zoomWeight + dHeight * zoomWeight) / 3;
 		// Calculate easing curve parameters for jump animation
 		this.mI = max(.5, .8 - dst * (c.is360 ? 1 : 2)); // Ease-in end point
 		this.mO = max(.05, min(.9, dst - (c.is360 ? .2 : .1))); // Ease-out start point

--- a/src/wasm/camera.ani.ts
+++ b/src/wasm/camera.ani.ts
@@ -141,8 +141,8 @@ export default class Ani {
 		noTrueNorth: bool, fn: i16, time : f64, correct : bool = false) : f64 {
 
 		// Store the final requested target view
-		this.lastView.setCenter(toCenterX, toCenterY, toWidth, toHeight);
-		this.vTo.setCenter(toCenterX, toCenterY, toWidth, toHeight);
+		this.lastView.set(toCenterX, toCenterY, toWidth, toHeight);
+		this.vTo.set(toCenterX, toCenterY, toWidth, toHeight);
 
 		// If this is a correction animation and one is already running, just update the target
 		if(correct && this.correcting) {
@@ -184,14 +184,14 @@ export default class Ani {
 		const fromCenterY = v.centerY;
 		const fromWidth = v.width;
 		const fromHeight = v.height;
-		f.setCenter(fromCenterX, fromCenterY, fromWidth, fromHeight);
+		f.set(fromCenterX, fromCenterY, fromWidth, fromHeight);
 
 		// Handle 360 wrap-around logic
 		if(c.is360) {
 			const longitudeDist = longitudeDistance(fromCenterX, toCenterX);
 			const optimizedCenterX = fromCenterX + longitudeDist;
 			toCenterX = optimizedCenterX; // Adjust the target centerX for shortest path
-			t.setCenter(toCenterX, toCenterY, toWidth, toHeight); // Update t with optimized centerX
+			t.set(toCenterX, toCenterY, toWidth, toHeight); // Update t with optimized centerX
 		}
 
 		// Apply viewport limits and aspect ratio correction if requested
@@ -210,10 +210,10 @@ export default class Ani {
 				const cX = t.centerX, cY = t.centerY;
 				if(t.aspect > f.aspect) {
 					const nh = t.width / f.aspect;
-					t.setCenter(cX, cY, t.width, nh);
+					t.set(cX, cY, t.width, nh);
 				} else {
 					const nw = t.height * f.aspect;
-					t.setCenter(cX, cY, nw, t.height);
+					t.set(cX, cY, nw, t.height);
 				}
 			}
 			// Check which edges are expanding/contracting
@@ -236,7 +236,7 @@ export default class Ani {
 				durFact=1.5;
 			}
 			// Otherwise, reset target view to original requested values (no aspect adjustment needed)
-			else t.setCenter(toCenterX, toCenterY, toWidth, toHeight);
+			else t.set(toCenterX, toCenterY, toWidth, toHeight);
 		}
 
 		// Apply final limits if this is a correction animation
@@ -275,7 +275,7 @@ export default class Ani {
 		// --- Start Animation ---
 		// If duration is zero, set view directly and finish
 		if(this.duration == 0) {
-			c.setView(t.x0, t.y0, t.x1, t.y1, false, true); // Set view, don't update lastView
+			c.setView(t.centerX, t.centerY, t.width, t.height, false, true); // Set view, don't update lastView
 			aniDone(this.canvas); // Notify JS host
 			this.stop(); // Reset animation state
 			return this.duration;
@@ -300,7 +300,7 @@ export default class Ani {
 
 	/** Updates the target view of a running animation. Used for corrections. */
 	updateTarget(toCenterX: f64, toCenterY: f64, toWidth: f64, toHeight: f64, limiting : bool = false) : void {
-		this.vTo.setCenter(toCenterX, toCenterY, toWidth, toHeight);
+		this.vTo.set(toCenterX, toCenterY, toWidth, toHeight);
 		if(limiting) this.vTo.limit(limiting); // Apply limits if requested
 	}
 
@@ -342,9 +342,9 @@ export default class Ani {
 
 	/** Sets the starting view for progress calculation in flyTo animations. */
 	setStartView(centerX: f64, centerY: f64, width: f64, height: f64, correctRatio: bool) : void {
-		this.vFrom.setCenter(centerX, centerY, width, height, correctRatio);
+		this.vFrom.set(centerX, centerY, width, height, correctRatio);
 		// Also set vTo initially to prevent issues if animation is interrupted early
-		this.vTo.setCenter(centerX, centerY, width, height, correctRatio);
+		this.vTo.set(centerX, centerY, width, height, correctRatio);
 	}
 
 	/**
@@ -381,7 +381,7 @@ export default class Ani {
 					interpCenterX = f.centerX + deltaX * pE;
 				}
 
-				this.canvas.view.setCenter(interpCenterX, interpCenterY, interpWidth, interpHeight);
+				this.canvas.view.set(interpCenterX, interpCenterY, interpWidth, interpHeight);
 				// Rest of omni logic remains
 			}
 

--- a/src/wasm/camera.ani.ts
+++ b/src/wasm/camera.ani.ts
@@ -154,6 +154,7 @@ export default class Ani {
 
 		// Determine if true north correction should be applied to the target view
 		this.vTo.correct = this.canvas.is360 && !noTrueNorth;
+		this.vFrom.correct = this.canvas.is360 && !!noTrueNorth;
 
 		const c = this.canvas;
 		const v = c.view; // Current view

--- a/src/wasm/camera.ani.ts
+++ b/src/wasm/camera.ani.ts
@@ -381,8 +381,19 @@ export default class Ani {
 					interpCenterX = f.centerX + deltaX * pE;
 				}
 
-				this.canvas.view.set(interpCenterX, interpCenterY, interpWidth, interpHeight);
-				// Rest of omni logic remains
+				this.canvas.setView(interpCenterX, interpCenterY, interpWidth, interpHeight, false, true);
+
+				// --- Apply Omni Object Rotation Step ---
+				if(this.omniDelta) {
+					// Interpolate omni frame index based on eased progress
+					let idx = this.omniStartIdx + <i32>(this.omniDelta * this.fn.get(min(1, p*1.5))); // Slightly faster rotation easing
+					const numPerLayer = this.canvas.images.length / this.canvas.omniNumLayers;
+					// Wrap index around
+					if(idx < 0) idx += numPerLayer;
+					if(idx >= numPerLayer) idx -= numPerLayer;
+					// Set the active image in the canvas
+					this.canvas.setActiveImage(idx, 0);
+				}
 			}
 
 			// --- Apply Zoom Animation Step (360 Perspective) ---

--- a/src/wasm/camera.ani.ts
+++ b/src/wasm/camera.ani.ts
@@ -118,10 +118,10 @@ export default class Ani {
 
 	/**
 	 * Starts or updates a "fly-to" animation to a target view rectangle.
-	 * @param toX0 Target view X0.
-	 * @param toY0 Target view Y0.
-	 * @param toX1 Target view X1.
-	 * @param toY1 Target view Y1.
+	 * @param toCenterX Target view center X.
+	 * @param toCenterY Target view center Y.
+	 * @param toWidth Target view width.
+	 * @param toHeight Target view height.
 	 * @param dur Requested duration in ms (-1 for automatic calculation).
 	 * @param speed Speed factor for automatic duration calculation.
 	 * @param perc Starting progress percentage (0-1).

--- a/src/wasm/camera.ts
+++ b/src/wasm/camera.ts
@@ -278,7 +278,7 @@ export default class Camera {
 		const overflowY:f64 = (ch / this.scale - vh) / 2;
 
 		// Apply overflow to center the view within the aspect ratio
-		v.set(v.centerX - overflowX, v.centerY - overflowY, v.width, v.height);
+		v.set(v.centerX, v.centerY, v.width + overflowX, v.height + overflowY);
 
 		// Store the initial view if coverStart is enabled
 		if(!this.inited && c.coverStart) this.canvas.ani.lastView.copy(v);

--- a/src/wasm/camera.ts
+++ b/src/wasm/camera.ts
@@ -276,11 +276,8 @@ export default class Camera {
 		const overflowX:f64 = (cw / this.scale - vw) / 2;
 		const overflowY:f64 = (ch / this.scale - vh) / 2;
 
-		// Adjust the logical view coordinates to account for the overflow (centering)
-		v.x0 -= overflowX;
-		v.y0 -= overflowY;
-		v.x1 += overflowX;
-		v.y1 += overflowY;
+		// Apply overflow to center the view within the aspect ratio
+		v.setCenter(v.centerX - overflowX, v.centerY - overflowY, v.width, v.height);
 
 		// Store the initial view if coverStart is enabled
 		if(!this.inited && c.coverStart) this.canvas.ani.lastView.copy(v);

--- a/src/wasm/camera.ts
+++ b/src/wasm/camera.ts
@@ -346,8 +346,7 @@ export default class Camera {
 		if(this.pinching) {
 			// If pinching, apply pan directly without animation or kinetic tracking
 			c.view.set(newCenterX, newCenterY, viewWidth, viewHeight);
-			const legacy = c.view.toLegacy();
-			c.setView(legacy[0], legacy[1], legacy[2], legacy[3], noLimit, false, false, false);
+			c.setView(newCenterX, newCenterY, viewWidth, viewHeight, noLimit, false, false, false);
 		} else if(this.isOutsideLimit() && !isKinetic) {
 			// If starting drag outside limits, animate back towards the limit
 			c.ani.toView(newCenterX, newCenterY, viewWidth, viewHeight, duration || 150, 0, 0, false, false, -1, false, 0, time, !noLimit); // correct=true
@@ -364,8 +363,7 @@ export default class Camera {
 				if (!noLimit) {
 					c.view.limit(false, false, c.freeMove); // Apply limits, passing freeMove
 				}
-				const legacy = c.view.toLegacy();
-				c.setView(legacy[0], legacy[1], legacy[2], legacy[3], noLimit, false, false, isKinetic);
+				c.setView(newCenterX, newCenterY, viewWidth, viewHeight, noLimit, false, false, isKinetic);
 				c.view.changed = true; // Mark as changed
 			} else {
 				// Otherwise, start a pan animation

--- a/src/wasm/camera.ts
+++ b/src/wasm/camera.ts
@@ -577,7 +577,7 @@ export default class Camera {
 
 		// Calculate target view width and height based on scale and canvas ratios
 		const w:f64 = isNaN(scale) && is360 ? c.view.width : (1/scale) * this.cpw;
-		const h:f64 = isNaN(scale) && is360 ? c.view.height : (1/scale) * this.cph * (is360 ? .5 : 1); // Height factor for 360?
+		const h:f64 = isNaN(scale) && is360 ? c.view.height : (1/scale) * this.cph; // Fixed: removed incorrect 360° height factor
 
 		// Clamp center coordinates if setting immediately (no animation) in 2D
 		if(dur==0 && !is360) {

--- a/src/wasm/camera.ts
+++ b/src/wasm/camera.ts
@@ -278,7 +278,7 @@ export default class Camera {
 		const overflowY:f64 = (ch / this.scale - vh) / 2;
 
 		// Apply overflow to center the view within the aspect ratio
-		v.setCenter(v.centerX - overflowX, v.centerY - overflowY, v.width, v.height);
+		v.set(v.centerX - overflowX, v.centerY - overflowY, v.width, v.height);
 
 		// Store the initial view if coverStart is enabled
 		if(!this.inited && c.coverStart) this.canvas.ani.lastView.copy(v);
@@ -345,7 +345,7 @@ export default class Camera {
 
 		if(this.pinching) {
 			// If pinching, apply pan directly without animation or kinetic tracking
-			c.view.setCenter(newCenterX, newCenterY, viewWidth, viewHeight);
+			c.view.set(newCenterX, newCenterY, viewWidth, viewHeight);
 			const legacy = c.view.toLegacy();
 			c.setView(legacy[0], legacy[1], legacy[2], legacy[3], noLimit, false, false, false);
 		} else if(this.isOutsideLimit() && !isKinetic) {
@@ -360,7 +360,7 @@ export default class Camera {
 				// Add step to kinetic tracker if not already kinetic movement
 				if(!isKinetic) c.kinetic.addStep(xPx*4, yPx*4, time); // Multiply delta for more sensitivity?
 				// Set view directly
-				c.view.setCenter(newCenterX, newCenterY, viewWidth, viewHeight);
+				c.view.set(newCenterX, newCenterY, viewWidth, viewHeight);
 				if (!noLimit) {
 					c.view.limit(false, false, c.freeMove); // Apply limits, passing freeMove
 				}

--- a/src/wasm/camera.ts
+++ b/src/wasm/camera.ts
@@ -274,8 +274,8 @@ export default class Camera {
 		if(!this.inited && c.coverStart) this.scale = this.coverScale;
 
 		// Calculate the overflow needed to center the logical view within the scaled viewport
-		const overflowX:f64 = (cw / this.scale - vw) / 2;
-		const overflowY:f64 = (ch / this.scale - vh) / 2;
+		const overflowX:f64 = (cw / this.scale - vw);
+		const overflowY:f64 = (ch / this.scale - vh);
 
 		// Apply overflow to center the view within the aspect ratio
 		v.set(v.centerX, v.centerY, v.width + overflowX, v.height + overflowY);

--- a/src/wasm/camera.ts
+++ b/src/wasm/camera.ts
@@ -182,15 +182,13 @@ export default class Camera {
 		this.coverScale = max(cpw, cph);
 
 		// Adjust coverScale if view limits are smaller than the image
-		const limitW = c.view.lX1 - c.view.lX0;
-		const limitH = c.view.lY1 - c.view.lY0;
-		const lRat = limitW / limitH; // Aspect ratio of the limit box
+		const lRat = c.view.lWidth / c.view.lHeight; // Aspect ratio of the limit box
 		c.view.limitChanged = false; // Reset flag
-		if(limitW < 1 || limitH < 1) { // If limits are active
+		if(c.view.lWidth < 1 || c.view.lHeight < 1) { // If limits are active
 			const rat = cpw / cph; // Aspect ratio of the canvas element
 			// Adjust cover scale based on the limiting dimension relative to aspect ratios
-			if(lRat < rat) this.coverScale /= limitW / rat;
-			else this.coverScale /= limitH * rat;
+			if(lRat < rat) this.coverScale /= c.view.lWidth / rat;
+			else this.coverScale /= c.view.lHeight * rat;
 		}
 
 		// Recalculate min/max scales based on new base scales
@@ -198,7 +196,7 @@ export default class Camera {
 
 		// If initialized and not animating, re-apply the last known view to adjust for resize
 		if(el.width && el.height && !this.canvas.ani.isStarted()) {
-			c.view.copy(c.ani.lastView); // Restore last animated view
+			c.view.copy(c.ani.lastView, true); // Restore last animated view
 			if(!c.is360) { // Only apply for 2D
 				const pLimit = c.ani.limit; // Preserve animation limit flag
 				c.ani.limit = false; // Temporarily disable limits for setView

--- a/src/wasm/camera.ts
+++ b/src/wasm/camera.ts
@@ -345,7 +345,7 @@ export default class Camera {
 			// If pinching, apply pan directly without animation or kinetic tracking
 			c.view.set(newCenterX, newCenterY, viewWidth, viewHeight);
 			c.setView(newCenterX, newCenterY, viewWidth, viewHeight, noLimit, false, false, false);
-		} else if(this.isOutsideLimit() && !isKinetic) {
+		} else if(!force && this.isOutsideLimit() && !isKinetic) {
 			// If starting drag outside limits, animate back towards the limit
 			c.ani.toView(newCenterX, newCenterY, viewWidth, viewHeight, duration || 150, 0, 0, false, false, -1, false, 0, time, !noLimit); // correct=true
 		} else {

--- a/src/wasm/canvas.ts
+++ b/src/wasm/canvas.ts
@@ -804,7 +804,7 @@ export default class Canvas {
 
 		if(this.width > 0) {
 			if(this.is360) {
-				this.webgl.setView360(centerX, centerY, width, height, noLimit, correctNorth);
+				this.webgl.setView(centerX, centerY, width, height, noLimit, correctNorth);
 				this.view.set(centerX, centerY, width, height); // Sync
 			} else if(this.camera.setView()) {
 				this.webgl.update();

--- a/src/wasm/canvas.ts
+++ b/src/wasm/canvas.ts
@@ -778,12 +778,14 @@ export default class Canvas {
 	// --- Unified View/Coordinate Accessors ---
 
 	/** Gets image coordinates from screen coordinates (delegates to Camera or WebGL). */
-	getCoo(x: f64, y: f64, abs: bool, noLimit: bool) : Float64Array {
-		return (this.is360 ? this.webgl.getCoo(x,y) : this.camera.getCoo(x, y, abs, noLimit)).toArray()
+	getCoo(x: f64, y: f64, abs: bool, noLimit: bool, correctNorth: bool = false) : Float64Array {
+		return (this.is360 ? this.webgl.getCoo(x,y, correctNorth) : this.camera.getCoo(x, y, abs, noLimit)).toArray()
 	}
 
 	/** Gets screen coordinates from image coordinates (delegates to Camera or WebGL). */
-	getXY(x: f64, y: f64, abs: bool, radius:f64, rotation:f64) : Float64Array { return (this.is360 ? this.webgl.getXYZ(x,y) : !isNaN(radius) ? this.camera.getXYOmni(x, y, radius, isNaN(rotation) ? 0 : rotation, abs) : this.camera.getXY(x, y, abs)).toArray() }
+	getXY(x: f64, y: f64, abs: bool, radius:f64, rotation:f64) : Float64Array {
+		return (this.is360 ? this.webgl.getXYZ(x,y) : !isNaN(radius) ? this.camera.getXYOmni(x, y, radius, isNaN(rotation) ? 0 : rotation, abs) : this.camera.getXY(x, y, abs)).toArray()
+	}
 
 	/** Gets the current logical view array. */
 	getView() : Float64Array { return this.view.arr }

--- a/src/wasm/canvas.ts
+++ b/src/wasm/canvas.ts
@@ -89,29 +89,7 @@ export default class Canvas {
 	/** Height of the current view (for viewport-style calculations). */
 	public viewHeight: f64 = 1;
 
-	// --- 3D Camera Frustum (for accurate 360 embed detection) ---
-	/** Camera forward direction vector X */
-	public cameraForwardX: f64 = 0;
-	/** Camera forward direction vector Y */
-	public cameraForwardY: f64 = 0;
-	/** Camera forward direction vector Z */
-	public cameraForwardZ: f64 = -1;
-	/** Camera up direction vector X */
-	public cameraUpX: f64 = 0;
-	/** Camera up direction vector Y */
-	public cameraUpY: f64 = 1;
-	/** Camera up direction vector Z */
-	public cameraUpZ: f64 = 0;
-	/** Camera right direction vector X */
-	public cameraRightX: f64 = 1;
-	/** Camera right direction vector Y */
-	public cameraRightY: f64 = 0;
-	/** Camera right direction vector Z */
-	public cameraRightZ: f64 = 0;
-	/** Field of view in radians */
-	public fieldOfView: f64 = 0;
-	/** Aspect ratio of viewport */
-	public aspectRatio: f64 = 1;
+
 
 	// --- Opacity/Fading ---
 	/** Current opacity value (linear). */
@@ -336,38 +314,7 @@ export default class Canvas {
 			|| (this.currentArea.width == 0 || this.currentArea.height == 0);
 	}
 
-	/** Calculates 3D camera frustum for accurate 360 embed visibility detection */
-	private calculate3DFrustum(): void {
-		if (this.is360) {
-			// Get camera orientation from View (which derives from centerX/Y)
-			const yaw = this.view.yaw;
-			const pitch = this.view.pitch;
-			
-			// Calculate camera direction vectors
-			this.cameraForwardX = Math.cos(pitch) * Math.sin(yaw);
-			this.cameraForwardY = Math.sin(pitch);
-			this.cameraForwardZ = Math.cos(pitch) * Math.cos(yaw);
-			
-			// Calculate up and right vectors (cross products)
-			this.cameraUpX = -Math.sin(pitch) * Math.sin(yaw);
-			this.cameraUpY = Math.cos(pitch);
-			this.cameraUpZ = -Math.sin(pitch) * Math.cos(yaw);
-			
-			this.cameraRightX = Math.cos(yaw);
-			this.cameraRightY = 0;
-			this.cameraRightZ = -Math.sin(yaw);
-			
-			// Calculate field of view from perspective
-			// webgl.perspective is the vertical FOV, we need horizontal FOV for proper detection
-			const verticalFOV = 2 * Math.atan(1 / this.webgl.perspective);
-			this.aspectRatio = this.el.width / this.el.height;
-			
-			// Calculate horizontal FOV from vertical FOV and aspect ratio
-			const halfVerticalFOV = verticalFOV / 2;
-			const halfHorizontalFOV = Math.atan(Math.tan(halfVerticalFOV) * this.aspectRatio);
-			this.fieldOfView = halfHorizontalFOV * 2;
-		}
-	}
+
 
 	/**
 	 * Calculates the min/max view bounds for 360 canvases.
@@ -442,7 +389,7 @@ export default class Canvas {
 		
 		// --- Calculate 3D Frustum ---
 		// Calculate 3D camera frustum for accurate 360 embed detection
-		this.calculate3DFrustum();
+		this.webgl.calculate3DFrustum();
 
 		// --- Opacity Animation ---
 		// Step opacity fade animation if needed

--- a/src/wasm/canvas.ts
+++ b/src/wasm/canvas.ts
@@ -683,13 +683,13 @@ export default class Canvas {
 	}
 
 	/** Sets the focus area for gallery/grid canvases. */
-	setFocus(centerX: f64, centerY: f64, width: f64, height: f64, noLimit:bool) : void {
-		const x0 = centerX - width / 2;
-		const y0 = centerY - height / 2;
-		const x1 = centerX + width / 2;
-		const y1 = centerY + height / 2;
+	setFocus(x0:f64, y0:f64, x1:f64, y1:f64, noLimit:bool) : void {
+		const centerX = (x0 + x1) / 2;
+		const centerY = (y0 + y1) / 2;
+		const width = x1 - x0;
+		const height = y1 - y0;
 
-		if(this.focus.equal(new View(this, centerX, centerY, width, height))) return;
+		if(this.focus.equals(centerX, centerY, width, height)) return;
 		this.activeImageIdx = -1;
 		for(let i=0;i<this.images.length;i++) {
 			const im = unchecked(this.images[i]);

--- a/src/wasm/canvas.ts
+++ b/src/wasm/canvas.ts
@@ -757,10 +757,6 @@ export default class Canvas {
 		if(isNaN(pitch)) pitch = this.webgl.pitch; // Use current pitch if not provided
 		this.webgl.setDirection(yaw, pitch, resetPersp ? this.webgl.defaultPerspective : 0);
 	}
-	/** Gets the current 360 viewport as center + dimensions format (delegates to WebGL). */
-	getView360() : Float64Array {
-		return this.webgl.getView360();
-	}
 	/** Gets the transformation matrix for a 360 embed (delegates to WebGL). */
 	getMatrix(x:f64,y:f64,s:f64,r:f64,rX:f64,rY:f64, rZ:f64,t:f64,sX:f64=1,sY:f64=1) : Float32Array {
 		// Adjust scale factor based on canvas width? Seems odd.

--- a/src/wasm/canvas.ts
+++ b/src/wasm/canvas.ts
@@ -157,7 +157,7 @@ export default class Canvas {
 		this.full = new View(this);         // Represents the full [0,0,1,1] view
 
 		// Initial view adjustment for 360 (often only shows middle vertically)
-		if(is360) { this.view.y0 = .25; this.view.y1 = .75; }
+		if(is360) { this.view.setCenter(0.5, 0.5, 1, 0.5); }
 
 		// If top-level canvas, initialize viewport and calculate initial camera state
 		if(!hasParent) {
@@ -507,15 +507,16 @@ export default class Canvas {
 		// --- Calculate Visible View Rectangle ---
 		// Determine the intersection of the logical view (v) and the portion of the parent's view (pV)
 		// that corresponds to the current animated area (a) of this canvas.
-		this.visible.x0 = max(v.x0, v.x0 + (pV.x0 - a.x0) / a.width * v.width);
-		this.visible.x1 = min(v.x1, v.x0 + (1 - (a.x1 - min(a.x1, pV.x1)) / a.width) * v.width);
+		let visX0 = max(v.x0, v.x0 + (pV.x0 - a.x0) / a.width * v.width);
+		let visX1 = min(v.x1, v.x0 + (1 - (a.x1 - min(a.x1, pV.x1)) / a.width) * v.width);
 		// Clamp horizontal coordinates for non-360 canvases
 		if(!this.is360) {
-			this.visible.x0 = max(0, this.visible.x0);
-			this.visible.x1 = min(1, this.visible.x1);
+			visX0 = max(0, visX0);
+			visX1 = min(1, visX1);
 		}
-		this.visible.y0 = max(max(0, v.y0), v.y0 + (pV.y0 - a.y0) / a.height * v.height);
-		this.visible.y1 = min(min(1, v.y1), v.y0 + (1 - (a.y1 - min(a.y1, pV.y1)) / a.height) * v.height);
+		let visY0 = max(max(0, v.y0), v.y0 + (pV.y0 - a.y0) / a.height * v.height);
+		let visY1 = min(min(1, v.y1), v.y0 + (1 - (a.y1 - min(a.y1, pV.y1)) / a.height) * v.height);
+		this.visible.set(visX0, visY0, visX1, visY1);
 
 		// --- Update Screen Viewport (el) ---
 		const ratio = hP ? 1 : c.ratio; // Use DPR only for top-level canvas
@@ -735,6 +736,7 @@ export default class Canvas {
 				const width = x1 - x0;
 				const height = y1 - y0;
 				this.webgl.setView360(centerX, centerY, width, height, noLimit, correctNorth);
+				this.view.setCenter(centerX, centerY, width, height); // Sync view to new model
 			} else if(this.camera.setView()) {
 				this.webgl.update(); // Update 2D camera scale/position and WebGL matrix
 			}

--- a/src/wasm/canvas.ts
+++ b/src/wasm/canvas.ts
@@ -555,11 +555,11 @@ export default class Canvas {
 	}
 
 	/** Sets the target area for this canvas within its parent, optionally animating. */
-	setArea(centerX: f64, centerY: f64, width: f64, height: f64, direct:bool, noDispatch:bool) : void {
+	setArea(x0: f64, y0: f64, x1: f64, y1: f64, direct:bool, noDispatch:bool) : void {
 		this.areaAniPaused = false; // Ensure animation is not paused
 		if(direct) { // Set area immediately
-			this.area.set(centerX, centerY, width, height);
-			this.currentArea.set(centerX, centerY, width, height);
+			this.area.setArea(x0, y0, x1, y1);
+			this.currentArea.setArea(x0, y0, x1, y1);
 		}
 		else { // Start animation
 			this.areaAniPerc = 0; // Reset progress
@@ -567,7 +567,7 @@ export default class Canvas {
 			this.ani.limit = false; // Disable view limits during area animation
 		}
 		// Set the target area
-		this.targetArea.set(centerX, centerY, width, height);
+		this.targetArea.setArea(x0, y0, x1, y1);
 		// Trigger initial calculation/step
 		this.partialView(noDispatch);
 	}

--- a/src/wasm/canvas.ts
+++ b/src/wasm/canvas.ts
@@ -403,14 +403,11 @@ export default class Canvas {
 			// --- 360 Transition Movement ---
 			// If moving between 360 spaces, apply translation based on opacity
 			if(this.main.distanceX != 0 || this.main.distanceY != 0) {
-				let rot:f64=0;
 				// If fading in, find the fading out canvas to get its yaw for smooth rotation transition
 				if(fadingIn) {
-					rot = -this.webgl.baseYaw; // Start with inverse of own base yaw
 					for(let i=0;i<this.main.canvases.length;i++) {
 						const c = unchecked(this.main.canvases[i]);
 						if(c != this && c.targetOpacity == 0 && c.opacity > 0) { // Find the one fading out
-							rot += c.webgl.baseYaw; // Add its base yaw
 							break;
 						}
 					}
@@ -422,7 +419,7 @@ export default class Canvas {
 					this.main.distanceX * fact * base360Distance,
 					this.main.distanceY * fact * base360Distance,
 					this.main.direction,
-					rot);
+					0);
 			}
 			animating = true; // Mark as animating if fading
 		}
@@ -831,10 +828,10 @@ export default class Canvas {
 		this.webgl.setDirection(yaw, pitch, resetPersp ? this.webgl.defaultPerspective : 0);
 	}
 	/** Gets the transformation matrix for a 360 embed (delegates to WebGL). */
-	getMatrix(x:f64,y:f64,s:f64,r:f64,rX:f64,rY:f64, rZ:f64,t:f64,sX:f64=1,sY:f64=1) : Float32Array {
+	getMatrix(x:f64,y:f64,s:f64,r:f64,rX:f64,rY:f64, rZ:f64,t:f64,sX:f64=1,sY:f64=1, noCorrectNorth: bool = false) : Float32Array {
 		// Adjust scale factor based on canvas width? Seems odd.
 		const fact:f64 = <f64>20000/this.width;
-		return this.webgl.getMatrix(x,y,s*fact,r,rX,rY,rZ,t,sX,sY).toArray()
+		return this.webgl.getMatrix(x,y,s*fact,r,rX,rY,rZ,t,sX,sY, noCorrectNorth).toArray()
 	}
 
 	// --- Animation Wrappers ---

--- a/src/wasm/exports.ts
+++ b/src/wasm/exports.ts
@@ -368,11 +368,11 @@ export function _setView360(c:Canvas, centerX: f64, centerY: f64, width: f64, he
 	const y1 = centerY + height / 2;
 	if(c.is360) {
 		// For 360 images, use direct camera control
-		c.setView360(centerX, centerY, width, height, noLimit, correctNorth);
+		c.setView(centerX, centerY, width, height, noLimit, correctNorth);
 		// Note: Limits are automatically applied in WebGL.setView360() -> setPerspective()
 		if(!noLastView) {
 			// Store last view in View format for compatibility
-			c.ani.lastView.set(x0, y0, x1, y1);
+			c.ani.lastView.set(centerX, centerY, width, height);
 		}
 	} else {
 		// For 2D images, convert to standard View format

--- a/src/wasm/exports.ts
+++ b/src/wasm/exports.ts
@@ -217,7 +217,7 @@ export function _getView(c:Canvas) : Float64Array { return c.view.toArray(); }
  * @returns Memory pointer to the `Float64Array` containing the coordinates [imageX, imageY, scale, w (depth), direction].
  */
 export function _getCoo(c:Canvas, x: f64, y: f64, abs: bool, noLimit: bool) : Float64Array {
-	return c.getCoo(x, y, abs, noLimit) };
+	return c.getCoo(x, y, abs, noLimit, true) };
 /**
  * Get an image's requested `[x, y]` pixel values for input coordinates `x` and `y`.
  * @param c The Canvas memory pointer in shared Wasm memory.

--- a/src/wasm/exports.ts
+++ b/src/wasm/exports.ts
@@ -431,10 +431,10 @@ export function _getScale(c:Canvas) : f64 { return c.getScale() }
 /**
  * Limit camera navigation boundaries.
  * @param c The Canvas memory pointer in shared Wasm memory.
- * @param x0 The viewport X0 coordinate.
- * @param y0 The viewport Y0 coordinate.
- * @param x1 The viewport X1 coordinate.
- * @param y1 The viewport Y1 coordinate.
+ * @param lCenterX The viewport center X coordinate.
+ * @param lCenterY The viewport center Y coordinate.
+ * @param lWidth The viewport width.
+ * @param lHeight The viewport height.
  */
 export function _setLimit(c:Canvas, lCenterX: f64, lCenterY: f64, lWidth: f64, lHeight: f64) : void {
 	if(c.view.lCenterX == lCenterX && c.view.lWidth == lWidth && c.view.lCenterY == lCenterY && c.view.lHeight == lHeight) return;
@@ -606,8 +606,8 @@ export function _getActiveImageIdx(c:Canvas) : i32 { return c.activeImageIdx }
  * @param y1 The viewport Y1 coordinate.
  * @param noLimit Don't update the zoom limits.
  */
-export function _setFocus(c:Canvas, centerX:f64, centerY:f64, width:f64, height:f64, noLimit:bool) : void {
-	c.setFocus(centerX, centerY, width, height, noLimit) }
+export function _setFocus(c:Canvas, x0:f64, y0:f64, x1:f64, y1:f64, noLimit:bool) : void {
+	c.setFocus(x0, y0, x1, y1, noLimit) }
 /**
  * Fade a main MicrioImage to a target opacity, including all of its sub-images.
  * @param c The Canvas memory pointer in shared Wasm memory.

--- a/src/wasm/exports.ts
+++ b/src/wasm/exports.ts
@@ -586,7 +586,7 @@ export function _flyTo(c:Canvas, toX0: f64, toY0: f64, toX1: f64, toY1: f64, dur
  */
 export function _flyToView360(c:Canvas, centerX: f64, centerY: f64, width: f64, height: f64, dur: f64, speed: f64,
 	perc: f64, isJump: bool, limit: bool, limitZoom: bool, toOmniIdx: i32, noTrueNorth: bool, fn:i16, time: f64) : f64 {
-	return c.camera.flyToView360(centerX, centerY, width, height, dur, speed, perc, isJump, limit, limitZoom, toOmniIdx, noTrueNorth, fn, time);
+	return c.camera.flyTo(centerX, centerY, width, height, dur, speed, perc, isJump, limit, limitZoom, toOmniIdx, noTrueNorth, fn, time);
 }
 /**
  * A zoom in/out animation.

--- a/src/wasm/exports.ts
+++ b/src/wasm/exports.ts
@@ -267,8 +267,8 @@ export function _getOmniXY(c:Canvas, x: f64, y: f64, z:f64) : Float64Array {
  * @param direct Don't animate.
  * @param noDispatch Don't do a frame draw after setting.
  */
-export function _setArea(c:Canvas, centerX:f64, centerY:f64, width:f64, height:f64, direct:bool, noDispatch:bool) : void {
-	c.setArea(centerX, centerY, width, height, direct, noDispatch) }
+export function _setArea(c:Canvas, x0:f64, y0:f64, x1:f64, y1:f64, direct:bool, noDispatch:bool) : void {
+	c.setArea(x0, y0, x1, y1, direct, noDispatch) }
 /**
  * Set the relative View area of an embedded image to render to.
  * @param i The sub image memory pointer in shared Wasm memory.
@@ -277,8 +277,8 @@ export function _setArea(c:Canvas, centerX:f64, centerY:f64, width:f64, height:f
  * @param x1 The viewport X1 coordinate.
  * @param y1 The viewport Y1 coordinate.
  */
-export function _setImageArea(i:Image, centerX:f64, centerY:f64, width:f64, height:f64) : void {
-	i.setArea(centerX, centerY, width, height) }
+export function _setImageArea(i:Image, x0:f64, y0:f64, x1:f64, y1:f64) : void {
+	i.setArea(x0, y0, x1, y1) }
 /**
  * Set an embedded sub-image rotation in 3d space for 360&deg; images.
  * @param i The sub image memory pointer in shared Wasm memory.

--- a/src/wasm/exports.ts
+++ b/src/wasm/exports.ts
@@ -243,10 +243,11 @@ export function _getXY(c:Canvas, x: f64, y: f64, abs: bool, radius:f64, rotation
  * @param t Optional Y translation in 3d space.
  * @param sX Optional X scaling.
  * @param sY Optional Y scaling.
+ * @param noCorrectNorth Don't correct for true north
  * @returns Memory pointer to the `Float32Array` containing the Matrix4 array.
  */
-export function _getMatrix(c:Canvas, x:f64,y:f64,s:f64,r:f64,rX:f64,rY:f64, rZ:f64,t:f64,sX:f64,sY:f64) : Float32Array {
-	return c.getMatrix(x,y,s,r,rX,rY,rZ,t,sX,sY) };
+export function _getMatrix(c:Canvas, x:f64,y:f64,s:f64,r:f64,rX:f64,rY:f64, rZ:f64,t:f64,sX:f64,sY:f64, noCorrectNorth: bool) : Float32Array {
+	return c.getMatrix(x,y,s,r,rX,rY,rZ,t,sX,sY, noCorrectNorth) };
 /**
  * Get the screen coordinates based on omni object xyz coordinates.
  * @param c The Canvas memory pointer in shared Wasm memory.
@@ -310,7 +311,7 @@ export function _getPMatrix(c:Canvas) : Float32Array { return c.webgl.pMatrix.ar
  * @param c The Canvas memory pointer in shared Wasm memory.
  * @returns The current yaw in radians.
  */
-export function _getYaw(c:Canvas) : f64 { return c.webgl.yaw + c.webgl.baseYaw }
+export function _getYaw(c:Canvas, noCorrectNorth: bool) : f64 { return c.webgl.yaw + (noCorrectNorth ? 0 : c.webgl.baseYaw) }
 /**
  * Get the current camera pitch (X-axis rotation) for 360&deg; images.
  * @param c The Canvas memory pointer in shared Wasm memory.

--- a/src/wasm/image.ts
+++ b/src/wasm/image.ts
@@ -191,9 +191,9 @@ export default class Image {
 		if (!this.canvas.is360) return false;
 		
 		// Calculate dot product between camera forward and embed position
-		const dotProduct = this.sphere3DX * this.canvas.cameraForwardX + 
-		                  this.sphere3DY * this.canvas.cameraForwardY + 
-		                  this.sphere3DZ * this.canvas.cameraForwardZ;
+		const dotProduct = this.sphere3DX * this.canvas.webgl.cameraForwardX + 
+		                  this.sphere3DY * this.canvas.webgl.cameraForwardY + 
+		                  this.sphere3DZ * this.canvas.webgl.cameraForwardZ;
 		
 		// If embed is behind camera, it's not visible
 		if (dotProduct < 0) return false;
@@ -201,14 +201,11 @@ export default class Image {
 		// Calculate angular distance from camera center to embed center
 		const angularDistance = Math.acos(Math.max(-1, Math.min(1, dotProduct)));
 		
-		// Calculate maximum angular distance for visibility
-		const halfFOV = this.canvas.fieldOfView / 2;
-		
 		// Use a more generous FOV for embed detection (250% of actual FOV)
-		const expandedHalfFOV = halfFOV * 2.5;
+		const expandedFOV = this.canvas.webgl.fieldOfView * 1.25;		
 		
 		// Embed is visible if it's within the expanded field of view
-		return angularDistance < expandedHalfFOV;
+		return angularDistance < expandedFOV;
 	}
 
 	/** Checks if the image's bounding box is completely outside the current view. */

--- a/src/wasm/shared.ts
+++ b/src/wasm/shared.ts
@@ -65,13 +65,13 @@ export class View {
 	get x0(): f64 { 
 		let cx = this.centerX;
 		if (this.canvas.is360) cx = mod1(cx);
-		return mod1(cx - this.width / 2); 
+		return this.canvas.is360 ? mod1(cx - this.width / 2) : (cx - this.width / 2); 
 	}
 	get y0(): f64 { return this.centerY - this.height / 2; }
 	get x1(): f64 { 
 		let cx = this.centerX;
 		if (this.canvas.is360) cx = mod1(cx);
-		return mod1(cx + this.width / 2); 
+		return this.canvas.is360 ? mod1(cx + this.width / 2) : (cx + this.width / 2); 
 	}
 	get y1(): f64 { return this.centerY + this.height / 2; }
 

--- a/src/wasm/shared.ts
+++ b/src/wasm/shared.ts
@@ -30,8 +30,6 @@ export class DrawRect {
 
 /** Represents the logical view rectangle within an image. */
 export class View {
-	/** Float64Array view of the legacy coordinates [x0, y0, x1, y1] for compatibility. */
-	readonly legacyArr : Float64Array = new Float64Array(4);
 	/** Float64Array view of the new coordinates [centerX, centerY, width, height]. */
 	readonly arr : Float64Array = new Float64Array(4);
 	/** Flag indicating if true north correction should be applied during set(). */
@@ -61,7 +59,6 @@ export class View {
 
 
 		this.toArray();
-		this.toLegacy();
 	}
 
 	// Legacy getters
@@ -106,7 +103,6 @@ export class View {
 		this.height = height;
 
 		this.toArray();
-		this.toLegacy();
 		this.changed = true;
 	}
 
@@ -133,7 +129,6 @@ export class View {
 		this.lHeight = v.lHeight;
 		this.changed = true;
 		this.toArray();
-		this.toLegacy();
 	}
 
 	/** Calculates the perspective value needed to achieve this view height in 360 mode. */
@@ -186,7 +181,6 @@ export class View {
 			this.width = nW;
 			this.height = nH;
 			this.toArray();
-			this.toLegacy();
 			return;
 		}
 
@@ -222,7 +216,6 @@ export class View {
 		}
 
 		this.toArray();
-		this.toLegacy();
 	}
 
 	// Update correctAspectRatio to use public props
@@ -238,7 +231,6 @@ export class View {
 			this.width = this.height * targetAspect;
 		}
 		this.toArray();
-		this.toLegacy();
 	}
 
 	/** Updates the shared Float64Array with the computed legacy view coordinates. */
@@ -248,15 +240,6 @@ export class View {
 		unchecked(this.arr[2] = this.width);
 		unchecked(this.arr[3] = this.height);
 		return this.arr;
-	}
-
-	/** Returns a Float64Array of the legacy [x0, y0, x1, y1]. */
-	toLegacy(): Float64Array {
-		unchecked(this.legacyArr[0] = this.x0);
-		unchecked(this.legacyArr[1] = this.y0);
-		unchecked(this.legacyArr[2] = this.x1);
-		unchecked(this.legacyArr[3] = this.y1);
-		return this.legacyArr;
 	}
 
 	/** Checks if this view is equal to another view. */

--- a/src/wasm/shared.ts
+++ b/src/wasm/shared.ts
@@ -215,7 +215,7 @@ export class View {
 	}
 
 	/** Applies navigation limits to the view coordinates. */
-	limit(correctZoom:bool, noLimit:bool = false): void {
+	limit(correctZoom:bool, noLimit:bool = false, freeMove:bool = false): void {
 		const c = this.canvas;
 		const mS = c.camera.minSize; // Minimum screen size factor
 		const s = this.getScale(); // Current effective scale
@@ -263,13 +263,15 @@ export class View {
 		const halfW = this._width / 2;
 		if (this.canvas.is360) {
 			this._centerX = mod1(this._centerX);
-		} else {
+		} else if (!freeMove) {
 			this._centerX = max(this.lX0 + halfW, min(this._centerX, this.lX1 - halfW));
 		}
 
 		// For Y (vertical, no wrap)
 		const halfH = this._height / 2;
-		this._centerY = max(this.lY0 + halfH, min(this._centerY, this.lY1 - halfH));
+		if (!freeMove) {
+			this._centerY = max(this.lY0 + halfH, min(this._centerY, this.lY1 - halfH));
+		}
 
 		this.toArray();
 	}

--- a/src/wasm/shared.ts
+++ b/src/wasm/shared.ts
@@ -127,15 +127,17 @@ export class View {
 	}
 
 	// Update copy to copy public props
-	copy(v:View) : void {
+	copy(v:View, excludeLimit:bool = false) : void {
 		this.centerX = v.centerX;
 		this.centerY = v.centerY;
 		this.width = v.width;
 		this.height = v.height;
-		this.lCenterX = v.lCenterX;
-		this.lCenterY = v.lCenterY;
-		this.lWidth = v.lWidth;
-		this.lHeight = v.lHeight;
+		if(!excludeLimit) {
+			this.lCenterX = v.lCenterX;
+			this.lCenterY = v.lCenterY;
+			this.lWidth = v.lWidth;
+			this.lHeight = v.lHeight;
+		}
 		this.changed = true;
 		this.toArray();
 	}
@@ -212,6 +214,7 @@ export class View {
 		// Limit Boundaries
 		const halfW = min(1, this.width) / 2;
 		const lHalfW = this.lWidth / 2;
+
 		if (this.canvas.is360) {
 			this.centerX = mod1(this.centerX);
 		} else if (!freeMove) {
@@ -252,11 +255,11 @@ export class View {
 	}
 
 	/** Checks if this view is equal to another view. */
-	equal(v:View) : bool {
-		return this.centerX == v.centerX
-			&& this.centerY == v.centerY
-			&& this.width == v.width
-			&& this.height == v.height;
+	equals(centerX:f64, centerY:f64, width:f64, height:f64) : bool {
+		return this.centerX == centerX
+			&& this.centerY == centerY
+			&& this.width == width
+			&& this.height == height;
 	}
 
 	/** Checks if this view represents the full image [0,0,1,1]. */

--- a/src/wasm/shared.ts
+++ b/src/wasm/shared.ts
@@ -209,6 +209,12 @@ export class View {
 			this.height = vh;
 		}
 
+		// Force view to fit within limits when they're smaller than full image
+		if(maxVw < 1 || maxVh < 1) {
+			this.width = min(this.width, maxVw);
+			this.height = min(this.height, maxVh);
+		}
+
 		if(noLimit) return;
 
 		// Limit Boundaries

--- a/src/wasm/shared.ts
+++ b/src/wasm/shared.ts
@@ -253,7 +253,7 @@ export class View {
 
 	/** Updates the shared Float64Array with the computed legacy view coordinates. */
 	toArray(): Float64Array {
-		unchecked(this.arr[0] = this.centerX);
+		unchecked(this.arr[0] = mod1(this.centerX + this.tnOffset));
 		unchecked(this.arr[1] = this.centerY);
 		unchecked(this.arr[2] = this.width);
 		unchecked(this.arr[3] = this.height);

--- a/src/wasm/shared.ts
+++ b/src/wasm/shared.ts
@@ -90,33 +90,8 @@ export class View {
 	get aspect() : f64 { return this.width / this.height }
 	get size() : f64 { return pyth(this.width, this.height) / pyth(1,1) }
 
-	// Update set to modify public props
-	set(x0:f64, y0:f64, x1:f64, y1:f64, preserveAspect: bool = false) : void {
-		let w = x1 - x0;
-		let h = y1 - y0;
-		let cx = x0 + w / 2;
-		let cy = y0 + h / 2;
-
-		if(preserveAspect) {
-			const cAr = min(1, this.width) / min(1, this.height);
-			if(w / h > cAr * 1.5 && w < this.width) { h = w * cAr; cy = y0 + h/2; }
-		}
-
-		const os = this.correct ? this.tnOffset : 0;
-		cx += os;
-
-		this.centerX = cx;
-		this.centerY = cy;
-		this.width = w;
-		this.height = h;
-
-		this.toArray();
-		this.toLegacy();
-		this.changed = true;
-	}
-
 	// Update setCenter to modify public props
-	setCenter(centerX: f64, centerY: f64, width: f64, height: f64, preserveAspect: bool = false): void {
+	set(centerX: f64, centerY: f64, width: f64, height: f64, preserveAspect: bool = false): void {
 		if (preserveAspect) {
 			const cAr = min(1, this.width) / min(1, this.height);
 			if (width / height > cAr * 1.5 && width < this.width) {

--- a/src/wasm/shared.ts
+++ b/src/wasm/shared.ts
@@ -106,6 +106,15 @@ export class View {
 		this.changed = true;
 	}
 
+	/** Sets the relative View area of a MicrioImage to render to, animates by default. Used in grids. */
+	setArea(x0: f64, y0: f64, x1: f64, y1: f64) : void {
+		this.centerX = (x0 + x1) / 2;
+		this.centerY = (y0 + y1) / 2;
+		this.width = x1 - x0;
+		this.height = y1 - y0;
+		this.toArray();
+	}
+
 	// Update setLimit to set public limit props
 	setLimit(lCenterX: f64, lCenterY: f64, lWidth: f64, lHeight: f64) : void {
 		this.lCenterX = lCenterX;

--- a/src/wasm/shared.ts
+++ b/src/wasm/shared.ts
@@ -210,7 +210,7 @@ export class View {
 		if(noLimit) return;
 
 		// Limit Boundaries
-		const halfW = this.width / 2;
+		const halfW = min(1, this.width) / 2;
 		const lHalfW = this.lWidth / 2;
 		if (this.canvas.is360) {
 			this.centerX = mod1(this.centerX);
@@ -218,7 +218,7 @@ export class View {
 			this.centerX = max(this.lCenterX - lHalfW + halfW, min(this.centerX, this.lCenterX + lHalfW - halfW));
 		}
 
-		const halfH = this.height / 2;
+		const halfH = min(1, this.height) / 2;
 		const lHalfH = this.lHeight / 2;
 		if (!freeMove) {
 			this.centerY = max(this.lCenterY - lHalfH + halfH, min(this.centerY, this.lCenterY + lHalfH - halfH));

--- a/src/wasm/webgl.ts
+++ b/src/wasm/webgl.ts
@@ -283,22 +283,6 @@ export default class WebGL {
 
 	/* ================== END EVENTS ================== */
 
-	/** Sets the camera orientation based on a target logical view (deprecated for 360 images). */
-	setView() : void {
-		// This method is deprecated for 360 images - use setView() instead
-		// Keep for backward compatibility and 2D image fallback only
-		const c = this.canvas;
-		// This shouldn't be called for 360 images anymore
-		if(c.is360) return;
-		
-		const v = c.view;
-		// Calculate target yaw and pitch from view center
-		this.yaw = ((v.centerX - this.offX) - .5) * PI * 2;
-		this.pitch = ((v.centerY - .5) * PI) * this.scaleY;
-		// Set perspective based on view height, applying limits
-		this.setPerspective(min(this.maxPerspective, v.height * PI * this.scaleY), true);
-	}
-
 	/** Sets the camera orientation directly. */
 	setDirection(yaw:f64, pitch:f64, persp:f64) : void {
 		// Apply base yaw (true north offset)

--- a/src/wasm/webgl.ts
+++ b/src/wasm/webgl.ts
@@ -394,7 +394,7 @@ export default class WebGL {
 	// --- Coordinate Conversion Functions ---
 
 	/** Converts screen pixel coordinates to 360 image coordinates [0-1]. */
-	getCoo(pxX:f64, pxY:f64) : Coordinates {
+	getCoo(pxX:f64, pxY:f64, correctNorth: bool = false) : Coordinates {
 		const el = this.canvas.el;
 		// Convert screen pixels to Normalized Device Coordinates (NDC) [-1, 1]
 		this.vec4.x = (pxX * el.ratio / el.width) * 2 - 1;
@@ -414,7 +414,7 @@ export default class WebGL {
 		// Normalize the resulting direction vector
 		this.vec4.normalize();
 		// Calculate longitude (yaw) using atan2, adjust for base yaw offset
-		this.coo.x = atan2(this.vec4.x,-this.vec4.z)/PI/2+.5+this.offX;
+		this.coo.x = atan2(this.vec4.x,-this.vec4.z)/PI/2+.5+(correctNorth ? 0 : this.offX);
 		// Calculate latitude (pitch) using asin, adjust for vertical scaling
 		this.coo.y = .5 - Math.asin(this.vec4.y) / PI / this.scaleY;
 		// Store current scale and depth/direction info

--- a/src/wasm/webgl.ts
+++ b/src/wasm/webgl.ts
@@ -485,7 +485,7 @@ export default class WebGL {
 	 * @param sY Additional scaling along the Y-axis.
 	 * @returns The calculated 4x4 transformation matrix.
 	 */
-	getMatrix(x: f64, y: f64, scale: f64, radius: f64, rX: f64, rY: f64, rZ: f64, transY: f64, sX: f64=1, sY: f64=1) : Mat4 {
+	getMatrix(x: f64, y: f64, scale: f64, radius: f64, rX: f64, rY: f64, rZ: f64, transY: f64, sX: f64=1, sY: f64=1, noCorrectNorth: bool = false) : Mat4 {
 		// Use default radius if not provided
 		if(isNaN(radius)) radius = this.radius;
 
@@ -515,7 +515,7 @@ export default class WebGL {
 		);
 
 		// 2. Apply base yaw (true north)
-		this.iMatrix.rotateY(this.baseYaw);
+		if(!noCorrectNorth) this.iMatrix.rotateY(this.baseYaw);
 
 		// 3. Translate to the point on the sphere surface
 		this.iMatrix.translate(

--- a/src/wasm/webgl.ts
+++ b/src/wasm/webgl.ts
@@ -266,8 +266,8 @@ export default class WebGL {
 		
 		const v = c.view;
 		// Calculate target yaw and pitch from view center
-		this.yaw = ((v.x0 - this.offX + v.width/2) - .5) * PI * 2;
-		this.pitch = (((v.y0 + v.height/2) - .5) * PI) * this.scaleY;
+		this.yaw = ((v.centerX - this.offX) - .5) * PI * 2;
+		this.pitch = ((v.centerY - .5) * PI) * this.scaleY;
 		// Set perspective based on view height, applying limits
 		this.setPerspective(min(this.maxPerspective, v.height * PI * this.scaleY), true);
 	}
@@ -296,14 +296,8 @@ export default class WebGL {
 		// Set perspective based on height, applying limits unless disabled
 		this.setPerspective(min(this.maxPerspective, height * PI * this.scaleY), noLimit);
 		
-		// Update the logical view to match the new camera state (for compatibility)
-		// Convert back to standard view format and store in canvas.view
-		const x0 = centerX - width / 2;
-		const y0 = centerY - height / 2;
-		const x1 = centerX + width / 2;
-		const y1 = centerY + height / 2;
-		this.canvas.view.set(x0, y0, x1, y1);
-		this.canvas.view.changed = true;
+		// Sync logical view with new camera state
+		this.syncLogicalView();
 	}
 
 	/** Gets the current camera state as 360-degree viewport format. */
@@ -336,14 +330,8 @@ export default class WebGL {
 		const height = this.perspective / PI / this.scaleY;
 		const width = height * (c.el.width == 0 ? 1 : .5 * sqrt(c.el.aspect)) / (c.aspect/2);
 		
-		// Convert to standard view format and update logical view
-		const x0 = centerX - width / 2;
-		const y0 = centerY - height / 2;
-		const x1 = centerX + width / 2;
-		const y1 = centerY + height / 2;
-		
-		// Update the logical view
-		c.view.set(x0, y0, x1, y1);
+		// Update the logical view using new model
+		c.view.setCenter(centerX, centerY, width, height);
 		c.view.changed = true;
 	}
 

--- a/src/wasm/webgl.ts
+++ b/src/wasm/webgl.ts
@@ -331,7 +331,7 @@ export default class WebGL {
 		const width = height * (c.el.width == 0 ? 1 : .5 * sqrt(c.el.aspect)) / (c.aspect/2);
 		
 		// Update the logical view using new model
-		c.view.setCenter(centerX, centerY, width, height);
+		c.view.set(centerX, centerY, width, height);
 		c.view.changed = true;
 	}
 

--- a/src/wasm/webgl.ts
+++ b/src/wasm/webgl.ts
@@ -285,7 +285,7 @@ export default class WebGL {
 
 	/** Sets the camera orientation based on a target logical view (deprecated for 360 images). */
 	setView() : void {
-		// This method is deprecated for 360 images - use setView360() instead
+		// This method is deprecated for 360 images - use setView() instead
 		// Keep for backward compatibility and 2D image fallback only
 		const c = this.canvas;
 		// This shouldn't be called for 360 images anymore
@@ -316,11 +316,11 @@ export default class WebGL {
 	}
 
 	/** Sets the camera orientation using 360-degree viewport format (center + dimensions). */
-	setView360(centerX: f64, centerY: f64, width: f64, height: f64, noLimit: bool = false, correctNorth: bool = false) : void {
+	setView(centerX: f64, centerY: f64, width: f64, height: f64, noLimit: bool = false, correctNorth: bool = false) : void {
 		// Apply true north correction if requested
 		const adjustedCenterX = correctNorth ? centerX + this.canvas.trueNorth : centerX;
 		
-		// Convert View360 directly to camera parameters
+		// Convert View directly to camera parameters
 		this.yaw = (adjustedCenterX - .5) * PI * 2;
 		this.pitch = (centerY - .5) * PI * this.scaleY;
 		// Set perspective based on height, applying limits unless disabled
@@ -338,7 +338,7 @@ export default class WebGL {
 		const c = this.canvas;
 		if(!c.is360) return; // Only for 360 images
 		
-		// Calculate current View360 from camera state
+		// Calculate current View from camera state
 		const centerX = mod1(this.yaw / (PI * 2) + .5);
 		const centerY = (this.pitch / this.scaleY) / PI + .5;
 		const height = this.perspective / PI / this.scaleY;

--- a/src/wasm/webgl.ts
+++ b/src/wasm/webgl.ts
@@ -61,9 +61,6 @@ export default class WebGL {
 	readonly vec4: Vec4 = new Vec4();
 	/** Reusable coordinates object for conversions. */
 	readonly coo: Coordinates = new Coordinates;
-	/** Float64Array buffer for 360-degree viewport [centerX, centerY, width, height] for efficient JS access. */
-	readonly view360Buffer : Float64Array = new Float64Array(4);
-
 
 	/** Horizontal offset based on trueNorth setting. */
 	offX:number = 0;
@@ -298,25 +295,6 @@ export default class WebGL {
 		
 		// Sync logical view with new camera state
 		this.syncLogicalView();
-	}
-
-	/** Gets the current camera state as 360-degree viewport format. */
-	getView360() : Float64Array {
-		// Calculate center coordinates from camera orientation
-		const centerX = mod1(this.yaw / (PI * 2) + .5);
-		const centerY = (this.pitch / this.scaleY) / PI + .5;
-		
-		// Calculate dimensions from perspective
-		const height = this.perspective / PI / this.scaleY;
-		const c = this.canvas;
-		const width = height * (c.el.width == 0 ? 1 : .5 * sqrt(c.el.aspect)) / (c.aspect/2);
-		
-		// Return as Float64Array for WASM export compatibility
-		unchecked(this.view360Buffer[0] = centerX);
-		unchecked(this.view360Buffer[1] = centerY);
-		unchecked(this.view360Buffer[2] = width);
-		unchecked(this.view360Buffer[3] = height);
-		return this.view360Buffer;
 	}
 
 	/** Synchronizes the logical view with the current camera state for 360 images. */


### PR DESCRIPTION
Implemented a totally new `View` model, to accomodate for 360&deg; images.

The legacy view `[x0,y0,x1,y1]` was not sufficient for 360&deg; images, since when a view was at either the north or south pole of the sphere, the corner coordinates would wrap around the sphere, creating an ambiguous situation.

The new `View` model is JSON:

```json
{
    centerX: number;
    centerY: number;
    width: number;
    height: number;
}
```

This allows for full freedom of viewport placement, both for 2D as 360 Micrio images.
