### PR TITLE
Fade in image embeds on load

### DIFF
--- a/src/embed/embed.ts
+++ b/src/embed/embed.ts
@@ -47,7 +47,7 @@ class MicrioEmbed extends MicrioElement<EmbedProps> {
 	#screenIsHDR = false;
 	#isBook3d = false;
 	#embedImageAsHtml = false;
-	#printGL = false;
+	#printGL = true;
 	#noEvents = false;
 	#href: string | undefined;
 	#hrefBlankTarget = false;
@@ -232,7 +232,14 @@ class MicrioEmbed extends MicrioElement<EmbedProps> {
 				},
 				style: this.#buttonStyle,
 				attrs: { 'data-scroll-through': '' },
-				parent: this.#container
+        parent: this.#container,
+        events: {
+          load: (e: Event) => {
+            console.log("test", this, e.target);
+            const img = e.target as HTMLImageElement;
+            img.setAttribute("data-loaded", "");
+          },
+        }
 			});
 		} else {
 			const $_lang = get(this.#micrio._lang);

--- a/src/embed/embed.ts
+++ b/src/embed/embed.ts
@@ -47,7 +47,7 @@ class MicrioEmbed extends MicrioElement<EmbedProps> {
 	#screenIsHDR = false;
 	#isBook3d = false;
 	#embedImageAsHtml = false;
-	#printGL = true;
+	#printGL = false;
 	#noEvents = false;
 	#href: string | undefined;
 	#hrefBlankTarget = false;
@@ -235,7 +235,6 @@ class MicrioEmbed extends MicrioElement<EmbedProps> {
         parent: this.#container,
         events: {
           load: (e: Event) => {
-            console.log("test", this, e.target);
             const img = e.target as HTMLImageElement;
             img.setAttribute("data-loaded", "");
           },

--- a/src/embed/image-embeds.css
+++ b/src/embed/image-embeds.css
@@ -1,4 +1,17 @@
+:root {
+  --micrio-embed-fade-in-duration: 0.6s;
+  --micrio-embed-fade-in-ease: ease;
+}
 
-micrio-image-embeds>* {
+micrio-image-embeds > * {
 	pointer-events: all;
+}
+
+micrio-image-embeds img {
+  opacity: 0;
+  transition: opacity var(--micrio-embed-fade-in-duration) var(--micrio-embed-fade-in-ease);
+}
+
+micrio-image-embeds img[data-loaded] {
+  opacity: 1;
 }


### PR DESCRIPTION
This PR is initially a conversation starter.
I believe embeds used to fade in with older Micrio versions. This is not the case in v7 and at least not since 5.4.28.

This PR applies the fade in only to the DOM version of an image embed by adding a load event listener and setting data-loaded on the image on the callback. 
The "animation" is done in css and configurable with custom properties. 

