### PR TITLE
FIX: Dispatch move events according to the docs / types

### DIFF
--- a/src/core/state.ts
+++ b/src/core/state.ts
@@ -124,6 +124,7 @@ export namespace State {
 				}
 				// Fire move callbacks
 				for(const fn of m._onMove) fn(detail);
+				m.events._dispatch('move', {image, view});
 			});
 
 			// Subscribe to local marker store changes


### PR DESCRIPTION
The 'move' event listed in the docs and types file is never dispatched. This PR adds the dispatch