### PR TITLE
Dispatch event when tiles are rendered

### DIFF
--- a/index.html
+++ b/index.html
@@ -92,7 +92,21 @@
 	</div>
 
 	<script>
+		// Loading-phase events fired by <micr-io>, in roughly the order they occur.
+		// 'tiles-rendered' is the newest addition; the rest are the existing ones.
+		const LOADING_EVENTS = ['pre-info', 'pre-data', 'print', 'load', 'tiles-rendered', 'show'];
+
 		const tests = [
+			// ── Events ─────────────────────────────────────────────
+			{ name: 'Loading events', id: 'dzzLm', type: 'events', description: 'Logs the new and existing loading events to the console',
+				htmlString: '<micr-io id="dzzLm"></micr-io>',
+				onRender: (micrio) => {
+					for (const ev of LOADING_EVENTS) {
+						micrio.addEventListener(ev, e => console.log(`[micrio] ${ev}`, e.detail));
+					}
+					console.log('[micrio] listening for loading events:', LOADING_EVENTS.join(', '));
+				} },
+
 			// ── Basic ──────────────────────────────────────────────
 			{ id: 'dzzLm', type: 'basic', description: 'Basic test image',
 				htmlString: '<micr-io id="dzzLm" lxang="nl" datxa-controls="false"></micr-io>',
@@ -261,6 +275,7 @@
 			noSel.style.display = 'none';
 			viewport.innerHTML = t.htmlString;
 			window.micrio = viewport.querySelector('micr-io')
+			if (window.micrio) t.onRender?.(window.micrio);
 		}
 
 		editBtn.addEventListener('click', () => {

--- a/src/core/image.ts
+++ b/src/core/image.ts
@@ -371,7 +371,10 @@ export class MicrioImage {
 				}
 				return l;
 			});
-			if(v && micrioRef.$current == this) micrioRef._switching.set(false);
+			if(v && micrioRef.$current == this) {
+				micrioRef._switching.set(false);
+				micrioRef.events._dispatch('tiles-rendered', this);
+			}
 		});
 
 		this.video.subscribe(v => this._video = v);

--- a/src/types/models/events.ts
+++ b/src/types/models/events.ts
@@ -20,6 +20,8 @@ export interface MicrioEventDetails {
 	'print': ImageInfo.ImageInfo;
 	/** Individual image data is loaded and Micrio will start rendering */
 	'load': MicrioImage;
+	/** The current image's tiles have finished rendering and it is fully faded in (opacity >= 1) */
+	'tiles-rendered': MicrioImage;
 	/** The user has switched available languages */
 	'lang-switch': string;
 


### PR DESCRIPTION
At the moment there is no event dispatched when the Mircio image is actually visible.
This PR adds a dispatched event fired when the base canvas's `visible` store flips to `true`, which only happens once `TileCanvas._opacity >= 1`

This event is useful when you want to visually hide the Micrio element until the image is visible.